### PR TITLE
tap-exchangeratesapi to tap-exchangeratehost

### DIFF
--- a/docs/01_run_local.md
+++ b/docs/01_run_local.md
@@ -65,19 +65,37 @@ Now let's run. Try entering this command below:
 ```
 ```shell
 
-[2020-12-28 22:02:09,182] [ WARNING] - 01_word_count/.secrets/secrets.yml does not exsist - (admin.py:223)
-[2020-12-28 22:02:09,297] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:02:09,634] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
-[2020-12-28 22:02:09,639] [    INFO] - Job started at 2020-12-28 22:02:09.639435 - (__init__.py:178)
-[2020-12-28 22:02:09,639] [    INFO] - Running pipeline word_count - (operators.py:193)
-[2020-12-28 22:02:09,647] [    INFO] - Checking return code of pid 2900 - (operators.py:262)
-[2020-12-28 22:02:09,647] [    INFO] - Checking return code of pid 2901 - (operators.py:262)
-[2020-12-28 22:02:09,648] [    INFO] - Pipeline word_count exited with code 0 - (task.py:32)
-[2020-12-28 22:02:09,648] [    INFO] - Job ended at 2020-12-28 22:02:09.648888 - (__init__.py:184)
-[2020-12-28 22:02:09,648] [    INFO] - Processed in 0:00:00.009453 - (__init__.py:186)
+[2021-04-07 05:16:06,537] [ WARNING] - 01_word_count/.secrets/secrets.yml does not exsist - (admin.py:223)
+[2021-04-07 05:16:06,665] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:16:07,024] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
+[2021-04-07 05:16:07,029] [    INFO] - Job started at 2021-04-07 05:16:07.029844 - (__init__.py:178)
+[2021-04-07 05:16:07,029] [    INFO] - Running pipeline word_count - (operators.py:194)
+[2021-04-07 05:16:07,040] [    INFO] - Checking return code of pid 4894 - (operators.py:263)
+[2021-04-07 05:16:07,041] [    INFO] - Checking return code of pid 4895 - (operators.py:263)
+[2021-04-07 05:16:07,042] [    INFO] - Pipeline word_count exited with code 0 - (task.py:32)
+[2021-04-07 05:16:07,042] [    INFO] - Job ended at 2021-04-07 05:16:07.042805 - (__init__.py:189)
+[2021-04-07 05:16:07,042] [    INFO] - Processed in 0:00:00.012961 - (__init__.py:191)
 ```
 
-Great! You just ran handoff task locally.
+
+If you see the output that looks like:
+
+```shell
+[2020-12-28 22:02:09,182] [ WARNING] - 01_word_count/.secrets/secrets.yml does not exsist - (admin.py:223)
+ [2020-12-28 22:02:09,297] [ INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+ [2020-12-28 22:02:09,634] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
+ [2020-12-28 22:02:09,639] [ INFO] - Job started at 2020-12-28 22:02:09.639435 - (__init__.py:178)
+ [2020-12-28 22:02:09,639] [ INFO] - Running pipeline word_count - (operators.py:193)
+ [2020-12-28 22:02:09,647] [ INFO] - Checking return code of pid 2900 - (operators.py:262)
+ [2020-12-28 22:02:09,647] [ INFO] - Checking return code of pid 2901 - (operators.py:262)
+ [2020-12-28 22:02:09,648] [ INFO] - Pipeline word_count exited with code 0 - (task.py:32)
+ [2020-12-28 22:02:09,648] [ INFO] - Job ended at 2020-12-28 22:02:09.648888 - (__init__.py:184)
+ [2020-12-28 22:02:09,648] [ INFO] - Processed in 0:00:00.009453 - (__init__.py:186)
+
+```
+
+
+Then great! You just ran handoff task locally.
     
 For now, let's not worry about the warnings in the log such as:
 
@@ -229,14 +247,14 @@ shorthands for options:
 ```
 ```shell
 
-[2020-12-28 22:02:10,090] [ WARNING] - 02_commands_and_vars/.secrets/secrets.yml does not exsist - (admin.py:223)
-[2020-12-28 22:02:10,211] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:02:10,549] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
-[2020-12-28 22:02:10,553] [    INFO] - Job started at 2020-12-28 22:02:10.553625 - (__init__.py:178)
-[2020-12-28 22:02:10,553] [    INFO] - Running commands show_content - (operators.py:141)
-[2020-12-28 22:02:10,560] [    INFO] - Pipeline show_content exited with code 0 - (task.py:32)
-[2020-12-28 22:02:10,560] [    INFO] - Job ended at 2020-12-28 22:02:10.560808 - (__init__.py:184)
-[2020-12-28 22:02:10,560] [    INFO] - Processed in 0:00:00.007183 - (__init__.py:186)
+[2021-04-07 05:16:07,498] [ WARNING] - 02_commands_and_vars/.secrets/secrets.yml does not exsist - (admin.py:223)
+[2021-04-07 05:16:07,632] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:16:07,988] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
+[2021-04-07 05:16:07,992] [    INFO] - Job started at 2021-04-07 05:16:07.992582 - (__init__.py:178)
+[2021-04-07 05:16:07,993] [    INFO] - Running commands show_content - (operators.py:142)
+[2021-04-07 05:16:08,002] [    INFO] - Pipeline show_content exited with code 0 - (task.py:32)
+[2021-04-07 05:16:08,002] [    INFO] - Job ended at 2021-04-07 05:16:08.002890 - (__init__.py:189)
+[2021-04-07 05:16:08,002] [    INFO] - Processed in 0:00:00.010308 - (__init__.py:191)
 ```
 
 Let's check out the contents of the second command:
@@ -319,13 +337,13 @@ Now let's run.
 ```
 ```shell
 
-[2020-12-28 22:02:11,117] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:02:11,467] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
-[2020-12-28 22:02:11,471] [    INFO] - Job started at 2020-12-28 22:02:11.471845 - (__init__.py:178)
-[2020-12-28 22:02:11,471] [    INFO] - Running commands show_curl_command - (operators.py:141)
-[2020-12-28 22:02:11,475] [    INFO] - Pipeline show_curl_command exited with code 0 - (task.py:32)
-[2020-12-28 22:02:11,475] [    INFO] - Job ended at 2020-12-28 22:02:11.475938 - (__init__.py:184)
-[2020-12-28 22:02:11,476] [    INFO] - Processed in 0:00:00.004093 - (__init__.py:186)
+[2021-04-07 05:16:08,582] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:16:08,937] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
+[2021-04-07 05:16:08,942] [    INFO] - Job started at 2021-04-07 05:16:08.942319 - (__init__.py:178)
+[2021-04-07 05:16:08,942] [    INFO] - Running commands show_curl_command - (operators.py:142)
+[2021-04-07 05:16:08,947] [    INFO] - Pipeline show_curl_command exited with code 0 - (task.py:32)
+[2021-04-07 05:16:08,947] [    INFO] - Job ended at 2021-04-07 05:16:08.947647 - (__init__.py:189)
+[2021-04-07 05:16:08,947] [    INFO] - Processed in 0:00:00.005328 - (__init__.py:191)
 ```
 
 show_curl_command_stdout.log shows the curl command with the actual username

--- a/docs/02_venv_and_install.md
+++ b/docs/02_venv_and_install.md
@@ -20,7 +20,7 @@ description: Fetch foreign exchange rates
 
 installs:
 - venv: tap
-  command: pip install tap-exchangeratesapi
+  command: pip install tap-exchangeratehost
 - venv: target
   command: pip install target-csv
 
@@ -32,7 +32,7 @@ tasks:
 - name: fetch_exchange_rates
   description: Fetch exchange rates
   pipeline:
-  - command: tap-exchangeratesapi
+  - command: tap-exchangeratehost
     args: --config files/tap-config.json
     venv: tap
   - command: python
@@ -46,7 +46,7 @@ deploy:
   cloud_provider: aws
   cloud_platform: fargate
   resource_group: handoff-etl
-  container_image: xxxxxxxxv
+  container_image: xxxxxxxxcsv
   task: exchange-rates-to-csv
 
 schedules:
@@ -72,12 +72,12 @@ We will use it later.)
 
 The project runs a pipeline that is a shell equivalent to
 
-    tap-exchangeratesapi | python files/stats_collector.py | target-csv
+    tap-exchangeratehost | python files/stats_collector.py | target-csv
 
 
 
 Before we can run this, we need to install a couple of Python packages:
-tap-exchangeratesapi and target-csv. The `install` section contains the
+tap-exchangeratehost and target-csv. The `install` section contains the 
 installation commands. Also notice `venv` entries for each command. handoff
 can create Python virtual enviroment for each command to avoid conflicting
 dependencies among the packages.
@@ -89,28 +89,28 @@ To install, run this command:
 ```
 ```shell
 
-[2020-12-28 22:02:12,049] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 05:16:09,548] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Requirement already satisfied: wheel in ./tap/lib/python3.6/site-packages (0.36.2)
-Collecting tap-exchangeratesapi
-  Using cached tap_exchangeratesapi-0.1.1-cp36-none-any.whl
-Collecting backoff==1.3.2
-  Using cached backoff-1.3.2-cp36-none-any.whl
-Collecting requests==2.21.0
-  Using cached requests-2.21.0-py2.py3-none-any.whl (57 kB)
-Collecting singer-python==5.3.3
-  Using cached singer_python-5.3.3-cp36-none-any.whl
+Collecting tap-exchangeratehost
+  Using cached tap_exchangeratehost-0.1.0-py3-none-any.whl (8.2 kB)
+Collecting requests>=2.23.0
+  Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
+Collecting singer-python>=5.3.0
+  Using cached singer_python-5.12.1-py3-none-any.whl
+Collecting urllib3<1.27,>=1.21.1
+  Using cached urllib3-1.26.4-py2.py3-none-any.whl (153 kB)
 .
 .
 .
-  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
+  Using cached python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
 Collecting pytzdata
   Using cached pytzdata-2020.1-py2.py3-none-any.whl (489 kB)
-Collecting tzlocal
-  Using cached tzlocal-2.1-py2.py3-none-any.whl (16 kB)
+Collecting six>=1.5
+  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
 Collecting pytz
-  Using cached pytz-2020.5-py2.py3-none-any.whl (510 kB)
+  Using cached pytz-2021.1-py2.py3-none-any.whl (510 kB)
 Installing collected packages: six, pytz, tzlocal, pytzdata, python-dateutil, simplejson, pendulum, singer-python, jsonschema, target-csv
-Successfully installed jsonschema-2.6.0 pendulum-1.2.0 python-dateutil-2.8.1 pytz-2020.5 pytzdata-2020.1 simplejson-3.11.1 singer-python-2.1.4 six-1.15.0 target-csv-0.3.0 tzlocal-2.1
+Successfully installed jsonschema-2.6.0 pendulum-1.2.0 python-dateutil-2.8.1 pytz-2021.1 pytzdata-2020.1 simplejson-3.11.1 singer-python-2.1.4 six-1.15.0 target-csv-0.3.0 tzlocal-2.1
 sucess
 ```
 
@@ -136,24 +136,24 @@ The following command, for example, sets the start_date as 7 days ago:
 ```
 ```shell
 
-[2020-12-28 22:02:27,352] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:02:27,707] [    INFO] - Job started at 2020-12-28 22:02:27.707674 - (__init__.py:178)
-[2020-12-28 22:02:27,707] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:193)
-[2020-12-28 22:02:27,726] [    INFO] - Checking return code of pid 3033 - (operators.py:262)
-[2020-12-28 22:02:28,313] [    INFO] - Checking return code of pid 3034 - (operators.py:262)
-[2020-12-28 22:02:28,320] [    INFO] - Checking return code of pid 3036 - (operators.py:262)
-[2020-12-28 22:02:28,338] [    INFO] - Pipeline fetch_exchange_rates exited with code 0 - (task.py:32)
-[2020-12-28 22:02:28,338] [    INFO] - Job ended at 2020-12-28 22:02:28.338382 - (__init__.py:184)
-[2020-12-28 22:02:28,338] [    INFO] - Processed in 0:00:00.630708 - (__init__.py:186)
+[2021-04-07 05:16:25,480] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:16:25,837] [    INFO] - Job started at 2021-04-07 05:16:25.837463 - (__init__.py:178)
+[2021-04-07 05:16:25,837] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:194)
+[2021-04-07 05:16:25,858] [    INFO] - Checking return code of pid 5024 - (operators.py:263)
+[2021-04-07 05:16:26,893] [    INFO] - Checking return code of pid 5025 - (operators.py:263)
+[2021-04-07 05:16:26,901] [    INFO] - Checking return code of pid 5027 - (operators.py:263)
+[2021-04-07 05:16:26,921] [    INFO] - Pipeline fetch_exchange_rates exited with code 0 - (task.py:32)
+[2021-04-07 05:16:26,922] [    INFO] - Job ended at 2021-04-07 05:16:26.921998 - (__init__.py:189)
+[2021-04-07 05:16:26,922] [    INFO] - Processed in 0:00:01.084535 - (__init__.py:191)
 ```
 
-Note: Mac OS local run should use `-v start_date=$(date -v -7d +%F)` instead of -I option.
+
 
 This task should have created a CSV file in artifacts directory:
 
 ```shell
 
-exchange_rate-20201228T220228.csv
+exchange_rate-20210407T051626.csv
 ```
 
 

--- a/docs/03_control_flow.md
+++ b/docs/03_control_flow.md
@@ -54,29 +54,29 @@ Now let's run:
 ```
 ```shell
 
-[2020-12-28 22:02:28,868] [ WARNING] - 05_foreach/.secrets/secrets.yml does not exsist - (admin.py:223)
-[2020-12-28 22:02:28,988] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:02:29,338] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
-[2020-12-28 22:02:29,342] [    INFO] - Job started at 2020-12-28 22:02:29.342212 - (__init__.py:178)
-[2020-12-28 22:02:29,342] [    INFO] - Running pipeline generate_files - (operators.py:193)
-[2020-12-28 22:02:29,345] [    INFO] - Running foreach loop - (operators.py:208)
-[2020-12-28 22:02:29,346] [    INFO] - Running pipeline make_id_files_1 - (operators.py:193)
-[2020-12-28 22:02:29,351] [    INFO] - Checking return code of pid 3072 - (operators.py:262)
-[2020-12-28 22:02:29,353] [    INFO] - Running pipeline make_id_files_2 - (operators.py:193)
-[2020-12-28 22:02:29,358] [    INFO] - Checking return code of pid 3076 - (operators.py:262)
+[2021-04-07 05:16:27,467] [ WARNING] - 05_foreach/.secrets/secrets.yml does not exsist - (admin.py:223)
+[2021-04-07 05:16:27,598] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:16:27,957] [ WARNING] - Environment variable HO_BUCKET is not set. Remote file read/write will fail. - (admin.py:132)
+[2021-04-07 05:16:27,961] [    INFO] - Job started at 2021-04-07 05:16:27.961542 - (__init__.py:178)
+[2021-04-07 05:16:27,961] [    INFO] - Running pipeline generate_files - (operators.py:194)
+[2021-04-07 05:16:27,965] [    INFO] - Running foreach loop - (operators.py:209)
+[2021-04-07 05:16:27,967] [    INFO] - Running pipeline make_id_files_1 - (operators.py:194)
+[2021-04-07 05:16:27,973] [    INFO] - Checking return code of pid 5063 - (operators.py:263)
+[2021-04-07 05:16:27,975] [    INFO] - Running pipeline make_id_files_2 - (operators.py:194)
+[2021-04-07 05:16:27,982] [    INFO] - Checking return code of pid 5067 - (operators.py:263)
 .
 .
 .
-[2020-12-28 22:02:29,372] [    INFO] - Running pipeline make_id_files_5 - (operators.py:193)
-[2020-12-28 22:02:29,378] [    INFO] - Checking return code of pid 3088 - (operators.py:262)
-[2020-12-28 22:02:29,381] [    INFO] - Checking return code of pid 3070 - (operators.py:262)
-[2020-12-28 22:02:29,381] [    INFO] - Pipeline generate_files exited with code 0 - (task.py:32)
-[2020-12-28 22:02:29,381] [    INFO] - Running pipeline verify_result - (operators.py:193)
-[2020-12-28 22:02:29,390] [    INFO] - Checking return code of pid 3094 - (operators.py:262)
-[2020-12-28 22:02:29,390] [    INFO] - Checking return code of pid 3096 - (operators.py:262)
-[2020-12-28 22:02:29,391] [    INFO] - Pipeline verify_result exited with code 0 - (task.py:32)
-[2020-12-28 22:02:29,391] [    INFO] - Job ended at 2020-12-28 22:02:29.391370 - (__init__.py:184)
-[2020-12-28 22:02:29,391] [    INFO] - Processed in 0:00:00.049158 - (__init__.py:186)
+[2021-04-07 05:16:28,000] [    INFO] - Running pipeline make_id_files_5 - (operators.py:194)
+[2021-04-07 05:16:28,007] [    INFO] - Checking return code of pid 5079 - (operators.py:263)
+[2021-04-07 05:16:28,012] [    INFO] - Checking return code of pid 5061 - (operators.py:263)
+[2021-04-07 05:16:28,012] [    INFO] - Pipeline generate_files exited with code 0 - (task.py:32)
+[2021-04-07 05:16:28,012] [    INFO] - Running pipeline verify_result - (operators.py:194)
+[2021-04-07 05:16:28,024] [    INFO] - Checking return code of pid 5085 - (operators.py:263)
+[2021-04-07 05:16:28,024] [    INFO] - Checking return code of pid 5087 - (operators.py:263)
+[2021-04-07 05:16:28,025] [    INFO] - Pipeline verify_result exited with code 0 - (task.py:32)
+[2021-04-07 05:16:28,025] [    INFO] - Job ended at 2021-04-07 05:16:28.025819 - (__init__.py:189)
+[2021-04-07 05:16:28,025] [    INFO] - Processed in 0:00:00.064277 - (__init__.py:191)
 ```
 
 
@@ -84,11 +84,11 @@ You can verify that 5 output files are created:
 
 ```shell
 
--rw-rw-r-- 1 ubuntu ubuntu 0 Dec 28 22:02 workspace_05/artifacts/out_1.txt
--rw-rw-r-- 1 ubuntu ubuntu 0 Dec 28 22:02 workspace_05/artifacts/out_2.txt
--rw-rw-r-- 1 ubuntu ubuntu 0 Dec 28 22:02 workspace_05/artifacts/out_3.txt
--rw-rw-r-- 1 ubuntu ubuntu 0 Dec 28 22:02 workspace_05/artifacts/out_4.txt
--rw-rw-r-- 1 ubuntu ubuntu 0 Dec 28 22:02 workspace_05/artifacts/out_5.txt
+-rw-rw-r-- 1 ubuntu ubuntu 0 Apr  7 05:16 workspace_05/artifacts/out_1.txt
+-rw-rw-r-- 1 ubuntu ubuntu 0 Apr  7 05:16 workspace_05/artifacts/out_2.txt
+-rw-rw-r-- 1 ubuntu ubuntu 0 Apr  7 05:16 workspace_05/artifacts/out_3.txt
+-rw-rw-r-- 1 ubuntu ubuntu 0 Apr  7 05:16 workspace_05/artifacts/out_4.txt
+-rw-rw-r-- 1 ubuntu ubuntu 0 Apr  7 05:16 workspace_05/artifacts/out_5.txt
 ```
 
 ### fork
@@ -109,7 +109,7 @@ description: Fetch foreign exchange rates
 
 installs:
 - venv: tap
-  command: pip install tap-exchangeratesapi
+  command: pip install tap-exchangeratehost
 - venv: target
   command: pip install target-csv
 
@@ -121,7 +121,7 @@ tasks:
 - name: fetch_exchange_rates
   description: Fetch exchange rates
   pipeline:
-  - command: tap-exchangeratesapi
+  - command: tap-exchangeratehost
     args: --config files/tap-config.json
     venv: tap
   - fork:
@@ -142,7 +142,7 @@ deploy:
   cloud_provider: aws
   cloud_platform: fargate
   resource_group: handoff-etl
-  container_image: xxxxxxxxv
+  container_image: xxxxxxxxcsv
   task: exchange-rates
 
 schedule:
@@ -168,28 +168,28 @@ Let's verify. First install workpace:
 ```
 ```shell
 
-[2020-12-28 22:02:29,961] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 05:16:28,607] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Requirement already satisfied: wheel in ./tap/lib/python3.6/site-packages (0.36.2)
-Collecting tap-exchangeratesapi
-  Using cached tap_exchangeratesapi-0.1.1-cp36-none-any.whl
-Collecting backoff==1.3.2
-  Using cached backoff-1.3.2-cp36-none-any.whl
-Collecting requests==2.21.0
-  Using cached requests-2.21.0-py2.py3-none-any.whl (57 kB)
-Collecting singer-python==5.3.3
-  Using cached singer_python-5.3.3-cp36-none-any.whl
+Collecting tap-exchangeratehost
+  Using cached tap_exchangeratehost-0.1.0-py3-none-any.whl (8.2 kB)
+Collecting requests>=2.23.0
+  Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
+Collecting singer-python>=5.3.0
+  Using cached singer_python-5.12.1-py3-none-any.whl
+Collecting urllib3<1.27,>=1.21.1
+  Using cached urllib3-1.26.4-py2.py3-none-any.whl (153 kB)
 .
 .
 .
-  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
-Collecting pytzdata
   Using cached pytzdata-2020.1-py2.py3-none-any.whl (489 kB)
-Collecting tzlocal
-  Using cached tzlocal-2.1-py2.py3-none-any.whl (16 kB)
+Collecting python-dateutil
+  Using cached python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
+Collecting six>=1.5
+  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
 Collecting pytz
-  Using cached pytz-2020.5-py2.py3-none-any.whl (510 kB)
+  Using cached pytz-2021.1-py2.py3-none-any.whl (510 kB)
 Installing collected packages: six, pytz, tzlocal, pytzdata, python-dateutil, simplejson, pendulum, singer-python, jsonschema, target-csv
-Successfully installed jsonschema-2.6.0 pendulum-1.2.0 python-dateutil-2.8.1 pytz-2020.5 pytzdata-2020.1 simplejson-3.11.1 singer-python-2.1.4 six-1.15.0 target-csv-0.3.0 tzlocal-2.1
+Successfully installed jsonschema-2.6.0 pendulum-1.2.0 python-dateutil-2.8.1 pytz-2021.1 pytzdata-2020.1 simplejson-3.11.1 singer-python-2.1.4 six-1.15.0 target-csv-0.3.0 tzlocal-2.1
 sucess
 ```
 
@@ -200,23 +200,23 @@ Now let's run:
 ```
 ```shell
 
-[2020-12-28 22:02:44,338] [ WARNING] - 06_fork/.secrets/secrets.yml does not exsist - (admin.py:223)
-[2020-12-28 22:02:44,460] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:02:44,812] [    INFO] - Job started at 2020-12-28 22:02:44.812863 - (__init__.py:178)
-[2020-12-28 22:02:44,813] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:193)
-[2020-12-28 22:02:44,815] [    INFO] - Forking the downstream... - (operators.py:216)
-[2020-12-28 22:02:44,816] [    INFO] - Running pipeline wide-format - (operators.py:193)
-[2020-12-28 22:02:44,822] [    INFO] - Running pipeline long-format - (operators.py:193)
-[2020-12-28 22:02:45,625] [    INFO] - Checking return code of pid 3187 - (operators.py:262)
-[2020-12-28 22:02:45,668] [    INFO] - Checking return code of pid 3191 - (operators.py:262)
-[2020-12-28 22:02:45,668] [    INFO] - Checking return code of pid 3193 - (operators.py:262)
+[2021-04-07 05:16:43,829] [ WARNING] - 06_fork/.secrets/secrets.yml does not exsist - (admin.py:223)
+[2021-04-07 05:16:43,961] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:16:44,328] [    INFO] - Job started at 2021-04-07 05:16:44.327973 - (__init__.py:178)
+[2021-04-07 05:16:44,328] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:194)
+[2021-04-07 05:16:44,332] [    INFO] - Forking the downstream... - (operators.py:217)
+[2021-04-07 05:16:44,332] [    INFO] - Running pipeline wide-format - (operators.py:194)
+[2021-04-07 05:16:44,342] [    INFO] - Running pipeline long-format - (operators.py:194)
+[2021-04-07 05:16:45,666] [    INFO] - Checking return code of pid 5178 - (operators.py:263)
+[2021-04-07 05:16:45,707] [    INFO] - Checking return code of pid 5182 - (operators.py:263)
+[2021-04-07 05:16:45,795] [    INFO] - Checking return code of pid 5184 - (operators.py:263)
 .
 .
 .
-[2020-12-28 22:02:45,686] [    INFO] - Checking return code of pid 3186 - (operators.py:262)
-[2020-12-28 22:02:45,687] [    INFO] - Pipeline fetch_exchange_rates exited with code 0 - (task.py:32)
-[2020-12-28 22:02:45,687] [    INFO] - Job ended at 2020-12-28 22:02:45.687229 - (__init__.py:184)
-[2020-12-28 22:02:45,687] [    INFO] - Processed in 0:00:00.874366 - (__init__.py:186)
+[2021-04-07 05:16:45,870] [    INFO] - Checking return code of pid 5177 - (operators.py:263)
+[2021-04-07 05:16:45,870] [    INFO] - Pipeline fetch_exchange_rates exited with code 0 - (task.py:32)
+[2021-04-07 05:16:45,870] [    INFO] - Job ended at 2021-04-07 05:16:45.870886 - (__init__.py:189)
+[2021-04-07 05:16:45,870] [    INFO] - Processed in 0:00:01.542913 - (__init__.py:191)
 ```
 
 The long format CSV file looks like this:
@@ -224,8 +224,8 @@ The long format CSV file looks like this:
 ```shell
 
 date,symbol,rate
-2020-12-21T00:00:00Z,CAD,1.2885895014
-2020-12-21T00:00:00Z,HKD,7.7530600509
+2021-03-31T00:00:00Z,AED,3.6732
+2021-03-31T00:00:00Z,AFN,77.250007
 ```
 
 

--- a/docs/04_set_up_aws_account.md
+++ b/docs/04_set_up_aws_account.md
@@ -76,6 +76,7 @@ For region, use one of these keys (for USA users, us-east-1 would do):
 
 ap-northeast-1
 ap-northeast-2
+ap-northeast-3
 ap-south-1
 ap-southeast-1
 ap-southeast-2

--- a/docs/05_run_remote_config.md
+++ b/docs/05_run_remote_config.md
@@ -30,15 +30,15 @@ Let's store project.yml and the project files to the remote store
 ```
 ```shell
 
-[2020-12-28 22:02:47,376] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:02:48,324] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?viewNested=true&hideStacks=false&stackId=arn:aws:cloudformation:us-east-1:xxxxxxxxxxxx:stack/dev-handoff-etl-bucket/xxxxxxxx85921ccb
+[2021-04-07 05:16:47,604] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:16:48,621] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?viewNested=true&hideStacks=false&stackId=arn:aws:cloudformation:us-east-1:xxxxxxxxxxxx:stack/dev-handoff-etl-bucket/xxxxxxxx21cc26bf
 ResponseMetadata:
   HTTPHeaders:
     content-length: '392'
     content-type: text/xml
-    date: Mon, 28 Dec 2020 22:02:48 GMT
-    x-amzn-requestid: xxxxxxxx7b10873a
+    date: Wed, 07 Apr 2021 05:16:49 GMT
+    x-amzn-requestid: xxxxxxxxab5f78c7
   HTTPStatusCode: 200
 ```
 
@@ -61,8 +61,8 @@ Try running these two commands:
 ```
 ```shell
 
-[2020-12-28 22:05:49,409] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:05:49,769] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 05:19:49,762] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:19:50,133] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 success
 ```
 
@@ -73,14 +73,14 @@ and this:
 ```
 ```shell
 
-[2020-12-28 22:05:50,740] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:05:51,100] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:05:51,235] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:05:51,527] [    INFO] - Uploading 04_install/files to bucket xxxxxxxx - (s3.py:122)
-[2020-12-28 22:05:51,527] [    INFO] - Files to be uploaded: ['04_install/files/target-config.json', '04_install/files/tap-config.json', '04_install/files/stats_collector.py'] - (s3.py:135)
-[2020-12-28 22:05:51,527] [    INFO] - Uploading 04_install/files/target-config.json to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/files/target-config.json - (s3.py:142)
-[2020-12-28 22:05:51,889] [    INFO] - Uploading 04_install/files/tap-config.json to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/files/tap-config.json - (s3.py:142)
-[2020-12-28 22:05:52,035] [    INFO] - Uploading 04_install/files/stats_collector.py to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/files/stats_collector.py - (s3.py:142)
+[2021-04-07 05:19:51,191] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:19:51,565] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:19:51,638] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:19:51,949] [    INFO] - Uploading 04_install/files to bucket xxxxxxxx - (s3.py:122)
+[2021-04-07 05:19:51,949] [    INFO] - Files to be uploaded: ['04_install/files/target-config.json', '04_install/files/tap-config.json', '04_install/files/stats_collector.py'] - (s3.py:135)
+[2021-04-07 05:19:51,949] [    INFO] - Uploading 04_install/files/target-config.json to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/files/target-config.json - (s3.py:142)
+[2021-04-07 05:19:52,316] [    INFO] - Uploading 04_install/files/tap-config.json to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/files/tap-config.json - (s3.py:142)
+[2021-04-07 05:19:52,476] [    INFO] - Uploading 04_install/files/stats_collector.py to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/files/stats_collector.py - (s3.py:142)
 See the files at https://s3.console.aws.amazon.com/s3/buckets/xxxxxxxx/dev-exchange-rates-to-csv/files/
 success
 ```
@@ -110,12 +110,12 @@ Try running (and enter 'y' to the confirmation):
 ```
 ```shell
 
-[2020-12-28 22:05:52,750] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 05:19:53,244] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Putting the following keys to remote parameter store:
   - username (task level)
   - password (task level)
   - google_client_secret (resource group level)
-Proceed? (y/N)[2020-12-28 22:05:53,109] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+Proceed? (y/N)[2021-04-07 05:19:53,621] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 See the parameters at https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table#list_parameter_filters=Name:Contains:/dev-handoff-etl/dev-exchange-rates-to-csv/username
 See the parameters at https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table#list_parameter_filters=Name:Contains:/dev-handoff-etl/dev-exchange-rates-to-csv/password
 See the parameters at https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table#list_parameter_filters=Name:Contains:/dev-handoff-etl/google_client_secret
@@ -144,28 +144,28 @@ Install the workspace as usual:
 ```
 ```shell
 
-[2020-12-28 22:05:54,296] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 05:19:54,894] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Requirement already satisfied: wheel in ./tap/lib/python3.6/site-packages (0.36.2)
-Collecting tap-exchangeratesapi
-  Using cached tap_exchangeratesapi-0.1.1-cp36-none-any.whl
-Collecting backoff==1.3.2
-  Using cached backoff-1.3.2-cp36-none-any.whl
-Collecting requests==2.21.0
-  Using cached requests-2.21.0-py2.py3-none-any.whl (57 kB)
-Collecting singer-python==5.3.3
-  Using cached singer_python-5.3.3-cp36-none-any.whl
+Collecting tap-exchangeratehost
+  Using cached tap_exchangeratehost-0.1.0-py3-none-any.whl (8.2 kB)
+Collecting requests>=2.23.0
+  Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
+Collecting singer-python>=5.3.0
+  Using cached singer_python-5.12.1-py3-none-any.whl
+Collecting certifi>=2017.4.17
+  Using cached certifi-2020.12.5-py2.py3-none-any.whl (147 kB)
 .
 .
 .
-  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
+  Using cached tzlocal-2.1-py2.py3-none-any.whl (16 kB)
 Collecting pytzdata
   Using cached pytzdata-2020.1-py2.py3-none-any.whl (489 kB)
-Collecting tzlocal
-  Using cached tzlocal-2.1-py2.py3-none-any.whl (16 kB)
+Collecting six>=1.5
+  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
 Collecting pytz
-  Using cached pytz-2020.5-py2.py3-none-any.whl (510 kB)
+  Using cached pytz-2021.1-py2.py3-none-any.whl (510 kB)
 Installing collected packages: six, pytz, tzlocal, pytzdata, python-dateutil, simplejson, pendulum, singer-python, jsonschema, target-csv
-Successfully installed jsonschema-2.6.0 pendulum-1.2.0 python-dateutil-2.8.1 pytz-2020.5 pytzdata-2020.1 simplejson-3.11.1 singer-python-2.1.4 six-1.15.0 target-csv-0.3.0 tzlocal-2.1
+Successfully installed jsonschema-2.6.0 pendulum-1.2.0 python-dateutil-2.8.1 pytz-2021.1 pytzdata-2020.1 simplejson-3.11.1 singer-python-2.1.4 six-1.15.0 target-csv-0.3.0 tzlocal-2.1
 sucess
 ```
 
@@ -179,29 +179,29 @@ Try running:
 ```
 ```shell
 
-[2020-12-28 22:06:08,935] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:06:09,305] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:06:09,724] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:06:10,159] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:66)
-[2020-12-28 22:06:10,716] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last - (s3.py:66)
-[2020-12-28 22:06:10,790] [ WARNING] - Nothing found in the location - (s3.py:83)
-[2020-12-28 22:06:10,790] [    INFO] - Job started at 2020-12-28 22:06:10.790266 - (__init__.py:178)
-[2020-12-28 22:06:10,790] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:193)
-[2020-12-28 22:06:10,807] [    INFO] - Checking return code of pid 3410 - (operators.py:262)
-[2020-12-28 22:06:11,409] [    INFO] - Checking return code of pid 3411 - (operators.py:262)
+[2021-04-07 05:20:10,559] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:20:10,943] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:20:11,395] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:20:11,896] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:66)
+[2021-04-07 05:20:12,462] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last - (s3.py:66)
+[2021-04-07 05:20:12,542] [ WARNING] - Nothing found in the location - (s3.py:83)
+[2021-04-07 05:20:12,543] [    INFO] - Job started at 2021-04-07 05:20:12.543068 - (__init__.py:178)
+[2021-04-07 05:20:12,543] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:194)
+[2021-04-07 05:20:12,570] [    INFO] - Checking return code of pid 5414 - (operators.py:263)
+[2021-04-07 05:20:13,673] [    INFO] - Checking return code of pid 5415 - (operators.py:263)
 .
 .
 .
-[2020-12-28 22:06:11,760] [    INFO] - Uploading workspace/artifacts to bucket xxxxxxxx - (s3.py:122)
-[2020-12-28 22:06:11,761] [    INFO] - Files to be uploaded: ['workspace/artifacts/fetch_exchange_rates_stdout.log', 'workspace/artifacts/exchange_rate-20201228T220611.csv', 'workspace/artifacts/collect_stats.json'] - (s3.py:135)
-[2020-12-28 22:06:11,761] [    INFO] - Uploading workspace/artifacts/fetch_exchange_rates_stdout.log to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/fetch_exchange_rates_stdout.log - (s3.py:142)
-[2020-12-28 22:06:11,917] [    INFO] - Uploading workspace/artifacts/exchange_rate-20201228T220611.csv to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20201228T220611.csv - (s3.py:142)
-[2020-12-28 22:06:12,074] [    INFO] - Uploading workspace/artifacts/collect_stats.json to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/collect_stats.json - (s3.py:142)
+[2021-04-07 05:20:14,038] [    INFO] - Uploading workspace/artifacts to bucket xxxxxxxx - (s3.py:122)
+[2021-04-07 05:20:14,038] [    INFO] - Files to be uploaded: ['workspace/artifacts/fetch_exchange_rates_stdout.log', 'workspace/artifacts/exchange_rate-20210407T052013.csv', 'workspace/artifacts/collect_stats.json'] - (s3.py:135)
+[2021-04-07 05:20:14,038] [    INFO] - Uploading workspace/artifacts/fetch_exchange_rates_stdout.log to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/fetch_exchange_rates_stdout.log - (s3.py:142)
+[2021-04-07 05:20:14,204] [    INFO] - Uploading workspace/artifacts/exchange_rate-20210407T052013.csv to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20210407T052013.csv - (s3.py:142)
+[2021-04-07 05:20:14,372] [    INFO] - Uploading workspace/artifacts/collect_stats.json to Amazon S3 bucket xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/collect_stats.json - (s3.py:142)
 See the files at https://s3.console.aws.amazon.com/s3/buckets/xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/
-[2020-12-28 22:06:12,220] [    INFO] - Copying recursively from s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/* to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:06:12.220644/* - (s3.py:17)
-[2020-12-28 22:06:12,483] [    INFO] - Copied s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/collect_stats.json to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:06:12.220644/collect_stats.json - (s3.py:53)
-[2020-12-28 22:06:12,662] [    INFO] - Copied s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20201228T220611.csv to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:06:12.220644/exchange_rate-20201228T220611.csv - (s3.py:53)
-[2020-12-28 22:06:12,855] [    INFO] - Copied s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/fetch_exchange_rates_stdout.log to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:06:12.220644/fetch_exchange_rates_stdout.log - (s3.py:53)
+[2021-04-07 05:20:14,567] [    INFO] - Copying recursively from s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/* to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T05:20:14.567230/* - (s3.py:17)
+[2021-04-07 05:20:14,837] [    INFO] - Copied s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/collect_stats.json to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T05:20:14.567230/collect_stats.json - (s3.py:53)
+[2021-04-07 05:20:15,019] [    INFO] - Copied s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20210407T052013.csv to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T05:20:14.567230/exchange_rate-20210407T052013.csv - (s3.py:53)
+[2021-04-07 05:20:15,211] [    INFO] - Copied s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/fetch_exchange_rates_stdout.log to s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T05:20:14.567230/fetch_exchange_rates_stdout.log - (s3.py:53)
 ```
 
 This time, we are not using the local project definition.
@@ -214,7 +214,7 @@ With this option, we pushed the result to the bucket under
 
 ```shell
 
-    s3://..../[2020-12-28 22:06:13,452] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+    s3://..../[2021-04-07 05:20:15,861] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 dev-exchange-rates-to-csv/artifacts/last
 
 ```
@@ -226,7 +226,7 @@ Also note that artifacts are automatically archived at each run at
 
 ```shell
 
-    s3://..../[2020-12-28 22:06:13,452] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+    s3://..../[2021-04-07 05:20:15,861] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 dev-exchange-rates-to-csv/artifacts/archives/
 
 
@@ -248,7 +248,7 @@ description: Fetch foreign exchange rates
 
 installs:
 - venv: tap
-  command: pip install tap-exchangeratesapi
+  command: pip install tap-exchangeratehost
 - venv: target
   command: pip install target-csv
 
@@ -260,7 +260,7 @@ tasks:
 - name: fetch_exchange_rates
   description: Fetch exchange rates
   pipeline:
-  - command: tap-exchangeratesapi
+  - command: tap-exchangeratehost
     args: --config files/tap-config.json
     venv: tap
   - command: python
@@ -274,7 +274,7 @@ deploy:
   cloud_provider: aws
   cloud_platform: fargate
   resource_group: handoff-etl
-  container_image: xxxxxxxxv
+  container_image: xxxxxxxxcsv
   task: exchange-rates-to-csv
 
 schedules:

--- a/docs/06_docker.md
+++ b/docs/06_docker.md
@@ -15,11 +15,11 @@ The build may take 5~10 minutes.
 ```
 ```shell
 
-[2020-12-28 22:06:14,443] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Build xxxxxxxxv:0.1 (y/N)? [2020-12-28 22:06:15,478] [    INFO] - Building xxxxxxxxv:0.1 - (impl.py:78)
-[2020-12-28 22:06:15,480] [    INFO] - Current working directory: /home/ubuntu/project/handoff/handoff/services/container/docker - (impl.py:82)
-[2020-12-28 22:06:15,480] [    INFO] - Looking for handoff source at /home/ubuntu/project/handoff/handoff/services/container/docker/../../../../ - (impl.py:84)
-[2020-12-28 22:06:15,481] [    INFO] - Found handoff. Copying to the build directory - (impl.py:86)
+[2021-04-07 05:20:16,893] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+Build xxxxxxxxcsv:0.1 (y/N)? [2021-04-07 05:20:18,011] [    INFO] - Building xxxxxxxxcsv:0.1 - (impl.py:78)
+[2021-04-07 05:20:18,012] [    INFO] - Current working directory: /home/ubuntu/project/handoff/handoff/services/container/docker - (impl.py:82)
+[2021-04-07 05:20:18,012] [    INFO] - Looking for handoff source at /home/ubuntu/project/handoff/handoff/services/container/docker/../../../../ - (impl.py:84)
+[2021-04-07 05:20:18,012] [    INFO] - Found handoff. Copying to the build directory - (impl.py:86)
 Step 1/27 : FROM ubuntu:18.04 ---> 2ca708c1c9cc
 Step 2/27 : MAINTAINER Daigo Tanaka <daigo.tanaka@gmail.com> ---> Using cache
  ---> 22aac56eb931
@@ -28,39 +28,36 @@ Step 3/27 : ENV DEBIAN_FRONTEND noninteractive ---> Using cache
 .
 .
 .
-Step 24/27 : RUN rm -fr workspace/artifacts ---> Running in a5ef8785b32f
- ---> 593b92ba4329
-Step 25/27 : RUN chmod a+x /usr/local/bin/* ---> Running in 00b172bb03f9
- ---> 80e84ccc0ac5
-Step 26/27 : ENTRYPOINT [ "/tini", "--" ] ---> Running in 95be61a89095
- ---> 0c94c0e4cdc8
-Step 27/27 : CMD handoff ${COMMAND:-run} -w workspace -a -v $(eval echo ${__VARS:-"dummy=1"}) -s ${HO_STAGE:-"test"} -a ---> Running in 7ed37e348260
- ---> b5bbffac014c
-Successfully built b5bbffac014c
-Successfully tagged xxxxxxxxv:0.1
+Step 24/27 : RUN rm -fr workspace/artifacts ---> Running in 54e949c94413
+ ---> d07e108da9a5
+Step 25/27 : RUN chmod a+x /usr/local/bin/* ---> Running in 24c417f453f5
+ ---> e12769b29295
+Step 26/27 : ENTRYPOINT [ "/tini", "--" ] ---> Running in dc421a4f8bf0
+ ---> 4e5339f471e2
+Step 27/27 : CMD handoff ${COMMAND:-run} -w workspace -a -v $(eval echo ${__VARS:-"dummy=1"}) -s ${HO_STAGE:-"dev"} -a ---> Running in 26163c1538b3
+ ---> 3773a14733dc
+Successfully built 3773a14733dc
+Successfully tagged xxxxxxxxcsv:0.1
 ```
 
 Now let's run the code in the Docker container.
 
 ```shell
-> handoff container run -p 04_install --envs __VARS='$(date -I -d "-7 day")'
+> handoff container run -p 04_install --envs __VARS='start_date=$(date -I -d "-7 day")'
 ```
 ```shell
 
-[2020-12-28 22:06:58,810] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:06:59,418] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Run xxxxxxxxv:0.1 (y/N)? [2020-12-28 22:07:01,003] [    INFO] - Found credentials in environment variables. - (credentials.py:1094)
-[2020-12-28 22:07:01,384] [    INFO] - Found credentials in environment variables. - (credentials.py:1094)
-[2020-12-28 22:07:01,851] [    INFO] - Found credentials in environment variables. - (credentials.py:1094)
-[2020-12-28 22:07:02,319] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:66)
-[2020-12-28 22:07:02,846] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last - (s3.py:66)
-[2020-12-28 22:07:03,415] [    INFO] - Job started at 2020-12-28 22:07:03.415462 - (__init__.py:178)
-[2020-12-28 22:07:03,415] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:193)
-[2020-12-28 22:07:03,434] [    INFO] - Checking return code of pid 28 - (operators.py:262)
+[2021-04-07 05:21:19,620] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:21:20,241] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+Run xxxxxxxxcsv:0.1 (y/N)? [2021-04-07 05:21:21,994] [    INFO] - Found credentials in environment variables. - (credentials.py:1100)
+[2021-04-07 05:21:22,381] [    INFO] - Found credentials in environment variables. - (credentials.py:1100)
+[2021-04-07 05:21:22,838] [    INFO] - Found credentials in environment variables. - (credentials.py:1100)
+[2021-04-07 05:21:23,340] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:66)
+[2021-04-07 05:21:23,885] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last - (s3.py:66)
+[2021-04-07 05:21:24,476] [    INFO] - Job started at 2021-04-07 05:21:24.476288 - (__init__.py:178)
+[2021-04-07 05:21:24,476] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:194)
+[2021-04-07 05:21:24,499] [    INFO] - Checking return code of pid 29 - (operators.py:263)
 ```
-
-Note: Mac OS local run should also use the date command with -I option because
-the command runs inside the container.
 
 Confirm the run by checking the logs. Also check the artifacts on S3:
 ```shell
@@ -83,29 +80,29 @@ AWS Elastic Container Registry. This may take a few minutes.
 ```
 ```shell
 
-[2020-12-28 22:07:08,485] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:07:09,020] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Repository xxxxxxxxv does not exist. Create (y/N)?[2020-12-28 22:07:09,410] [    INFO] - Creating repository xxxxxxxxv - (__init__.py:94)
-Push xxxxxxxxv:0.1 to xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com (y/N)? id: e36ccb76f941 status: Preparing
-id: b5bfa90522bd status: Preparing
-id: 5cdca8bd36d3 status: Preparing
-id: 6c96d483f769 status: Preparing
-id: 476b387d4f0a status: Preparing
-id: 0cc9d5b47311 status: Preparing
-id: b779c87a670a status: Preparing
+[2021-04-07 05:21:30,325] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:21:30,881] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+Repository xxxxxxxxcsv does not exist. Create (y/N)?[2021-04-07 05:21:31,275] [    INFO] - Creating repository xxxxxxxxcsv - (__init__.py:94)
+Push xxxxxxxxcsv:0.1 to xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com (y/N)? id: 28f470206a3c status: Preparing
+id: 673e03fa99d2 status: Preparing
+id: d3ca5be6fad9 status: Preparing
+id: 2b6cda83ca7f status: Preparing
+id: 1eee0a143c43 status: Preparing
+id: cc51cd368615 status: Preparing
+id: 19c09b0ffae8 status: Preparing
 .
 .
 .
-id: 6734fdd29c24 [========================>                          ]  265.8MB/540.8MB
-id: 6734fdd29c24 [===========================>                       ]    298MB/540.8MB
-id: 6734fdd29c24 [==============================>                    ]  331.4MB/540.8MB
-id: 6734fdd29c24 [=================================>                 ]  362.9MB/540.8MB
-id: 6734fdd29c24 [====================================>              ]  394.8MB/540.8MB
-id: 6734fdd29c24 [=======================================>           ]    429MB/540.8MB
-id: 6734fdd29c24 [==========================================>        ]  461.4MB/540.8MB
-id: 6734fdd29c24 [=============================================>     ]  493.5MB/540.8MB
-id: 6734fdd29c24 [================================================>  ]  526.1MB/540.8MB
-id: 6734fdd29c24 status: Pushed
+id: b61bcef8f912 [===========================>                       ]  265.6MB/480.2MB
+id: b61bcef8f912 [==============================>                    ]  293.4MB/480.2MB
+id: a1aa3da2a80a status: Pushed
+id: b61bcef8f912 [=================================>                 ]  323.1MB/480.2MB
+id: b61bcef8f912 [====================================>              ]  351.2MB/480.2MB
+id: b61bcef8f912 [=======================================>           ]  379.9MB/480.2MB
+id: b61bcef8f912 [==========================================>        ]  409.2MB/480.2MB
+id: b61bcef8f912 [=============================================>     ]  437.8MB/480.2MB
+id: b61bcef8f912 [================================================>  ]  466.9MB/480.2MB
+id: b61bcef8f912 status: Pushed
 ```
 
 Confirm that the Docker image has been uploaded to:

--- a/docs/07_fargate.md
+++ b/docs/07_fargate.md
@@ -16,15 +16,15 @@ To make this process easy, handoff packed everything up in a command:
 ```
 ```shell
 
-[2020-12-28 22:08:07,033] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:08:08,023] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?viewNested=true&hideStacks=false&stackId=arn:aws:cloudformation:us-east-1:xxxxxxxxxxxx:stack/dev-handoff-etl-resources/xxxxxxxx70f6c675
+[2021-04-07 05:22:36,032] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:22:37,698] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?viewNested=true&hideStacks=false&stackId=arn:aws:cloudformation:us-east-1:xxxxxxxxxxxx:stack/dev-handoff-etl-resources/xxxxxxxx8e67507f
 ResponseMetadata:
   HTTPHeaders:
     content-length: '395'
     content-type: text/xml
-    date: Mon, 28 Dec 2020 22:08:08 GMT
-    x-amzn-requestid: xxxxxxxx653fb3ca
+    date: Wed, 07 Apr 2021 05:22:38 GMT
+    x-amzn-requestid: xxxxxxxx373c818b
   HTTPStatusCode: 200
 ```
 
@@ -51,16 +51,16 @@ Now it's time to deploy the task and here is the command:
 ```
 ```shell
 
-[2020-12-28 22:11:09,397] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:11:10,436] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:11:10,737] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?viewNested=true&hideStacks=false&stackId=arn:aws:cloudformation:us-east-1:xxxxxxxxxxxx:stack/dev-exchange-rates-to-csv/xxxxxxxx6fcea8bf
+[2021-04-07 05:25:39,116] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:25:40,223] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:25:40,585] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?viewNested=true&hideStacks=false&stackId=arn:aws:cloudformation:us-east-1:xxxxxxxxxxxx:stack/dev-exchange-rates-to-csv/xxxxxxxxa46f2873
 ResponseMetadata:
   HTTPHeaders:
     content-length: '395'
     content-type: text/xml
-    date: Mon, 28 Dec 2020 22:11:10 GMT
-    x-amzn-requestid: xxxxxxxx26242316
+    date: Wed, 07 Apr 2021 05:25:40 GMT
+    x-amzn-requestid: xxxxxxxx95b74d11
 ```
 
 
@@ -82,20 +82,20 @@ Once the task is created, try running on Fargate.
 To do so, run this command:
 
 ```shell
-> handoff cloud run -p 04_install --envs __VARS='$(date -I -d "-7 day")'
+> handoff cloud run -p 04_install --envs __VARS='start_date=$(date -I -d "-7 day")'
 ```
 ```shell
 
-[2020-12-28 22:14:11,902] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:14:12,858] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:14:12,893] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Check the task at https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/dev-handoff-etl-resources/tasks/xxxxxxxxf4d1
+[2021-04-07 05:28:41,844] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:28:42,903] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:28:42,947] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+Check the task at https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/dev-handoff-etl-resources/tasks/xxxxxxxx31d8
 ResponseMetadata:
   HTTPHeaders:
-    content-length: '1530'
+    content-length: '1610'
     content-type: application/x-amz-json-1.1
-    date: Mon, 28 Dec 2020 22:14:13 GMT
-    x-amzn-requestid: xxxxxxxx2cd32826
+    date: Wed, 07 Apr 2021 05:28:44 GMT
+    x-amzn-requestid: xxxxxxxx5dd33cb2
 ```
 
 At the end of the log, you should see a line like:
@@ -152,8 +152,16 @@ To check the status of the task, do:
 ```
 ```shell
 
-[2020-12-28 22:19:15,336] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:16,307] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 05:33:45,436] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:33:46,471] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+- cpu: '256'
+  createdAt: 2021-04-07 05:28:44.757000+00:00
+  duration: '0:00:05.962000'
+  lastStatus: STOPPED
+  memory: '512'
+  startedAt: 2021-04-07 05:29:49.038000+00:00
+  taskArn: arn:aws:ecs:us-east-1:xxxxxxxxxxxx:task/dev-handoff-etl-resources/xxxxxxxx31d8
+  taskDefinitionArn: arn:aws:ecs:us-east-1:xxxxxxxxxxxx:task-definition/xxxxxxxx-rates-to-csv:8
 ```
 
 
@@ -164,16 +172,16 @@ To view the log, do:
 ```
 ```shell
 
-[2020-12-28 22:19:17,233] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:18,246] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-2020-12-28 22:15:08.809000 - [2020-12-28 22:15:08,809] [    INFO] - Found credentials in environment variables. - (credentials.py:1094)
-2020-12-28 22:15:09.100000 - [2020-12-28 22:15:09,100] [    INFO] - Found credentials in environment variables. - (credentials.py:1094)
-2020-12-28 22:15:09.458000 - [2020-12-28 22:15:09,458] [    INFO] - Found credentials in environment variables. - (credentials.py:1094)
-2020-12-28 22:15:09.738000 - [2020-12-28 22:15:09,738] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:66)
-2020-12-28 22:15:09.920000 - [2020-12-28 22:15:09,919] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last - (s3.py:66)
-2020-12-28 22:15:10.090000 - [2020-12-28 22:15:10,090] [    INFO] - Job started at 2020-12-28 22:15:10.090135 - (__init__.py:178)
-2020-12-28 22:15:10.090000 - [2020-12-28 22:15:10,090] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:193)
-2020-12-28 22:15:10.200000 - [2020-12-28 22:15:10,193] [    INFO] - Checking return code of pid 32 - (operators.py:262)
+[2021-04-07 05:33:47,612] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:33:48,680] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+2021-04-07 05:29:50.819000 - [2021-04-07 05:29:50,819] [    INFO] - Found credentials in environment variables. - (credentials.py:1100)
+2021-04-07 05:29:51.039000 - [2021-04-07 05:29:51,038] [    INFO] - Found credentials in environment variables. - (credentials.py:1100)
+2021-04-07 05:29:51.421000 - [2021-04-07 05:29:51,421] [    INFO] - Found credentials in environment variables. - (credentials.py:1100)
+2021-04-07 05:29:51.756000 - [2021-04-07 05:29:51,756] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:66)
+2021-04-07 05:29:51.940000 - [2021-04-07 05:29:51,940] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last - (s3.py:66)
+2021-04-07 05:29:52.116000 - [2021-04-07 05:29:52,116] [    INFO] - Job started at 2021-04-07 05:29:52.116310 - (__init__.py:178)
+2021-04-07 05:29:52.116000 - [2021-04-07 05:29:52,116] [    INFO] - Running pipeline fetch_exchange_rates - (operators.py:194)
+2021-04-07 05:29:52.221000 - [2021-04-07 05:29:52,221] [    INFO] - Checking return code of pid 32 - (operators.py:263)
 ```
 
 The log can also take the parameters such as start_time, end_time, and follow:

--- a/docs/08_schedule.md
+++ b/docs/08_schedule.md
@@ -20,7 +20,7 @@ description: Fetch foreign exchange rates
 
 installs:
 - venv: tap
-  command: pip install tap-exchangeratesapi
+  command: pip install tap-exchangeratehost
 - venv: target
   command: pip install target-csv
 
@@ -32,7 +32,7 @@ tasks:
 - name: fetch_exchange_rates
   description: Fetch exchange rates
   pipeline:
-  - command: tap-exchangeratesapi
+  - command: tap-exchangeratehost
     args: --config files/tap-config.json
     venv: tap
   - command: python
@@ -46,7 +46,7 @@ deploy:
   cloud_provider: aws
   cloud_platform: fargate
   resource_group: handoff-etl
-  container_image: xxxxxxxxv
+  container_image: xxxxxxxxcsv
   task: exchange-rates-to-csv
 
 schedules:
@@ -71,14 +71,14 @@ Alternatively, we can pass those values to handoff with `--vars` (`-v` for short
 
 
 ```shell
-> handoff cloud schedule create -p 04_install -v target_id=1 cron='24 22 * * ? *' --envs __VARS='start_date=2020-12-21'
+> handoff cloud schedule create -p 04_install -v target_id=1 cron='38 05 * * ? *' --envs __VARS='start_date=$(date -I -d "-7 day")'
 ```
 ```shell
 
-[2020-12-28 22:19:19,499] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:20,476] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:20,862] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:21,243] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 05:33:49,692] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:33:50,714] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:33:51,126] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 05:33:51,888] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Check the status at https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/dev-handoff-etl-resources/scheduledTasks
 - FailedEntries: []
   FailedEntryCount: 0

--- a/docs/09_cleanup.md
+++ b/docs/09_cleanup.md
@@ -9,9 +9,9 @@ First unschedule the task:
 ```
 ```shell
 
-[2020-12-28 22:19:22,511] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:23,479] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-Check the status at https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/dev-handoff-etl-resources/scheduledTasks
+[2021-04-07 04:58:22,666] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:23,699] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+No schedules found
 ```
 
 Then delete the task:
@@ -21,15 +21,15 @@ Then delete the task:
 ```
 ```shell
 
-[2020-12-28 22:19:24,439] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:25,394] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 04:58:24,591] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:25,597] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?filteringText=dev-exchange-rates-to-csv
 ResponseMetadata:
   HTTPHeaders:
     content-length: '212'
     content-type: text/xml
-    date: Mon, 28 Dec 2020 22:19:25 GMT
-    x-amzn-requestid: xxxxxxxx285d21ed
+    date: Wed, 07 Apr 2021 04:58:25 GMT
+    x-amzn-requestid: xxxxxxxx84dd5d3d
   HTTPStatusCode: 200
 ```
 
@@ -40,15 +40,15 @@ If there is no other task in the same resource group, we can delete it:
 ```
 ```shell
 
-[2020-12-28 22:19:26,423] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:27,374] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 04:58:26,702] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:27,735] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?filteringText=dev-handoff-etl
 ResponseMetadata:
   HTTPHeaders:
     content-length: '212'
     content-type: text/xml
-    date: Mon, 28 Dec 2020 22:19:26 GMT
-    x-amzn-requestid: xxxxxxxxb32881fa
+    date: Wed, 07 Apr 2021 04:58:27 GMT
+    x-amzn-requestid: xxxxxxxxcb90d89f
   HTTPStatusCode: 200
 ```
 
@@ -59,10 +59,10 @@ Here is how to delete the configurations from SSM Parameter Store:
 ```
 ```shell
 
-[2020-12-28 22:19:28,530] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:28,887] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:28,940] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:29,232] [    INFO] - Deleting dev-exchange-rates-to-csv/project.yml from bucket xxxxxxxx - (s3.py:207)
+[2021-04-07 04:58:28,900] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:29,269] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:29,507] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:29,830] [    INFO] - Deleting dev-exchange-rates-to-csv/project.yml from bucket xxxxxxxx - (s3.py:207)
 success
 ```
 
@@ -73,10 +73,10 @@ Here is how to delete the files from S3 bucket:
 ```
 ```shell
 
-[2020-12-28 22:19:30,125] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:30,482] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:30,516] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:155)
-[2020-12-28 22:19:30,957] [    INFO] - Deleted [{'Key': 'dev-exchange-rates-to-csv/files/stats_collector.py'}, {'Key': 'dev-exchange-rates-to-csv/files/tap-config.json'}, {'Key': 'dev-exchange-rates-to-csv/files/target-config.json'}] - (s3.py:182)
+[2021-04-07 04:58:30,710] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:31,077] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:31,127] [    INFO] - GET s3://xxxxxxxx/dev-exchange-rates-to-csv/files - (s3.py:155)
+[2021-04-07 04:58:31,542] [    INFO] - Deleted [{'Key': 'dev-exchange-rates-to-csv/files/stats_collector.py'}, {'Key': 'dev-exchange-rates-to-csv/files/tap-config.json'}, {'Key': 'dev-exchange-rates-to-csv/files/target-config.json'}] - (s3.py:182)
 success
 ```
 
@@ -87,12 +87,12 @@ And here is how to delete the secrets from AWS Systems Manager Parameter Store:
 ```
 ```shell
 
-[2020-12-28 22:19:31,524] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 04:58:32,133] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Deleting the following keys to remote parameter store:
   - username (task level)
   - password (task level)
   - google_client_secret (resource group level)
-Proceed? (y/N)[2020-12-28 22:19:31,889] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+Proceed? (y/N)[2021-04-07 04:58:32,509] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 success
 ```
 
@@ -103,16 +103,16 @@ If there is no other task in the same resource group, we can delete the bucket, 
 ```
 ```shell
 
-[2020-12-28 22:19:33,123] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
-[2020-12-28 22:19:34,087] [ WARNING] - This will only delete the CloudFormation stack. The bucket xxxxxxxx will be retained. - (__init__.py:421)
-[2020-12-28 22:19:34,103] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1182)
+[2021-04-07 04:58:33,806] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
+[2021-04-07 04:58:34,823] [ WARNING] - This will only delete the CloudFormation stack. The bucket xxxxxxxx will be retained. - (__init__.py:421)
+[2021-04-07 04:58:34,837] [    INFO] - Found credentials in shared credentials file: ~/.aws/credentials - (credentials.py:1223)
 Check the progress at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?filteringText=xxxxxxxx
 ResponseMetadata:
   HTTPHeaders:
     content-length: '212'
     content-type: text/xml
-    date: Mon, 28 Dec 2020 22:19:33 GMT
-    x-amzn-requestid: xxxxxxxx8e808ac4
+    date: Wed, 07 Apr 2021 04:58:34 GMT
+    x-amzn-requestid: xxxxxxxxd719bc59
 ```
 
 The previous command only deleted the CloudFormation stack, but not the bucket itself.
@@ -123,26 +123,29 @@ Here is how to delete all the files in s3://xxxxxxxx bucket. This cannot be reve
 ```
 ```shell
 
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:07:05.020533/exchange_rate-20201228T220703.csv
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:15:12.784517/exchange_rate-20201228T221511.csv
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:06:12.220644/collect_stats.json
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:06:12.220644/exchange_rate-20201228T220611.csv
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:06:12.220644/fetch_exchange_rates_stdout.log
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:15:12.784517/collect_stats.json
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:15:12.784517/fetch_exchange_rates_stdout.log
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:15:12.784517/exchange_rate-20201228T220703.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:45:53.451784/exchange_rate-20210407T044432.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:44:34.289110/fetch_exchange_rates_stdout.log
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:54:21.040265/exchange_rate-20210407T044549.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:54:21.040265/fetch_exchange_rates_stdout.log
 delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/collect_stats.json
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20201228T220611.csv
-.
-.
-.
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20201228T220703.csv
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20201228T221511.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:44:34.289110/collect_stats.json
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20210407T044432.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:54:21.040265/exchange_rate-20210407T045419.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/exchange_rate-20210407T044549.csv
 delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/last/fetch_exchange_rates_stdout.log
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:07:05.020533/collect_stats.json
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:15:12.784517/exchange_rate-20201228T220611.csv
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:07:05.020533/fetch_exchange_rates_stdout.log
-delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2020-12-28T22:07:05.020533/exchange_rate-20201228T220611.csv
+.
+.
+.
+delete: s3://xxxxxxxx/xxxxxxxxse/files/schema/earthquakes.json
+delete: s3://xxxxxxxx/xxxxxxxxse/files/custom_spec.json
+delete: s3://xxxxxxxx/xxxxxxxxse/files/tap_config.json
+delete: s3://xxxxxxxx/xxxxxxxxse/files/target_config.json
+delete: s3://xxxxxxxx/xxxxxxxxse/project.yml
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:54:21.040265/collect_stats.json
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:45:53.451784/exchange_rate-20210407T044549.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:54:21.040265/exchange_rate-20210407T044432.csv
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:45:53.451784/fetch_exchange_rates_stdout.log
+delete: s3://xxxxxxxx/dev-exchange-rates-to-csv/artifacts/archives/2021-04-07T04:44:34.289110/exchange_rate-20210407T044432.csv
 ```
 
 Here is how to delete s3://xxxxxxxx bucket. The bucket must be empty. This cannot be reversed:
@@ -155,22 +158,22 @@ Here is how to delete s3://xxxxxxxx bucket. The bucket must be empty. This canno
 remove_bucket: xxxxxxxx
 ```
 
-Now delete xxxxxxxxv repository from ECR. This cannot be reversed.
+Now delete xxxxxxxxcsv repository from ECR. This cannot be reversed.
 --force option will ignore that we still have images in the repository.
 
 ```shell
-> aws ecr delete-repository --repository-name xxxxxxxxv --force
+> aws ecr delete-repository --repository-name xxxxxxxxcsv --force
 ```
 ```shell
 
 {
     "repository": {
-        "repositoryUri": "xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/xxxxxxxxv", 
+        "repositoryUri": "xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/xxxxxxxxcsv", 
         "registryId": "xxxxxxxxxxxx", 
         "imageTagMutability": "IMMUTABLE", 
-        "repositoryArn": "arn:aws:ecr:us-east-1:xxxxxxxxxxxx:repository/xxxxxxxxv", 
-        "repositoryName": "xxxxxxxxv", 
-        "createdAt": 1609193229.0
+        "repositoryArn": "arn:aws:ecr:us-east-1:xxxxxxxxxxxx:repository/xxxxxxxxcsv", 
+        "repositoryName": "xxxxxxxxcsv", 
+        "createdAt": 1617770758.0
     }
 }
 ```
@@ -179,14 +182,14 @@ The following code removes all the locally stored Docker images containing the
 project name:
 
 ```shell
-> docker images --format '{{.Repository}}:{{.Tag}}' |grep xxxxxxxxv | xargs -I % sh -c 'docker rmi --force %'
+> docker images --format '{{.Repository}}:{{.Tag}}' |grep xxxxxxxxcsv | xargs -I % sh -c 'docker rmi --force %'
 ```
 ```shell
 
-Untagged: xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/xxxxxxxxv:0.1
-Untagged: xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/xxxxxxxxv@sha256:xxxxxxxxxxxxxxxx300a78fc
-Untagged: xxxxxxxxv:0.1
-Deleted: sha256:xxxxxxxxxxxxxxxxd27649e5
+Untagged: xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/xxxxxxxxcsv:0.1
+Untagged: xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/xxxxxxxxcsv@sha256:xxxxxxxxxxxxxxxxd86f3d81
+Untagged: xxxxxxxxcsv:0.1
+Deleted: sha256:xxxxxxxxxxxxxxxx558280db
 ```
 
 That's all.

--- a/handoff/test_projects/04_install/project.yml
+++ b/handoff/test_projects/04_install/project.yml
@@ -3,7 +3,7 @@ description: Fetch foreign exchange rates
 
 installs:
 - venv: tap
-  command: pip install tap-exchangeratesapi
+  command: pip install tap-exchangeratehost
 - venv: target
   command: pip install target-csv
 
@@ -15,7 +15,7 @@ tasks:
 - name: fetch_exchange_rates
   description: Fetch exchange rates
   pipeline:
-  - command: tap-exchangeratesapi
+  - command: tap-exchangeratehost
     args: --config files/tap-config.json
     venv: tap
   - command: python
@@ -29,7 +29,7 @@ deploy:
   cloud_provider: aws
   cloud_platform: fargate
   resource_group: handoff-etl
-  container_image: tap-exchange-rates-target-csv
+  container_image: tap-exchangeratehost-target-csv
   task: exchange-rates-to-csv
 
 schedules:

--- a/handoff/test_projects/06_fork/project.yml
+++ b/handoff/test_projects/06_fork/project.yml
@@ -3,7 +3,7 @@ description: Fetch foreign exchange rates
 
 installs:
 - venv: tap
-  command: pip install tap-exchangeratesapi
+  command: pip install tap-exchangeratehost
 - venv: target
   command: pip install target-csv
 
@@ -15,7 +15,7 @@ tasks:
 - name: fetch_exchange_rates
   description: Fetch exchange rates
   pipeline:
-  - command: tap-exchangeratesapi
+  - command: tap-exchangeratehost
     args: --config files/tap-config.json
     venv: tap
   - fork:
@@ -36,7 +36,7 @@ deploy:
   cloud_provider: aws
   cloud_platform: fargate
   resource_group: handoff-etl
-  container_image: tap-exchange-rates-target-csv
+  container_image: tap-exchangeratehost-target-csv
   task: exchange-rates
 
 schedule:

--- a/handoff/test_projects/scripts/aws_get_started/02_venv_and_install
+++ b/handoff/test_projects/scripts/aws_get_started/02_venv_and_install
@@ -39,14 +39,14 @@ Prompt
 echo "
 The project runs a pipeline that is a shell equivalent to
 
-    tap-exchangeratesapi | python files/stats_collector.py | target-csv
+    tap-exchangeratehost | python files/stats_collector.py | target-csv
 "
 
 Prompt
 
 echo '
 Before we can run this, we need to install a couple of Python packages:
-tap-exchangeratesapi and target-csv. The `install` section contains the 
+tap-exchangeratehost and target-csv. The `install` section contains the 
 installation commands. Also notice `venv` entries for each command. handoff
 can create Python virtual enviroment for each command to avoid conflicting
 dependencies among the packages.


### PR DESCRIPTION
exchangerates.io now requires signup and access key. It is no longer an ideal example via tap-exchangeratesapi.
So we are switching to tap-exchangeratehost