### PR TITLE
Tighten default error log metric filter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -51,7 +51,7 @@ A major release with improved interface and new features.
 4. Configuration and secret management (AWS Systems Manager Parameter Store)
 5. Simple switch between production and devlopment stages
 6. Docker image management (AWS Elastic Container Registry)
-7. Artifacts management (AWS Elastic Container Registry)
+7. Artifacts management (AWS Simple Cloud Storage)
 8. Log management (AWS CloudWatch)
 9. Shared resource management (Virtual Private Cloud, Security Group)
 10. No need to pay and maintain a dedicated virtual instances!

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ## History
 
+### 0.4.3 (2026-07-18)
+
+- Tighten the default CloudWatch error metric filter to match task-failure signals instead of broad error substrings.
+
 ### 0.4.2 (2025-09-10)
 
 - Modernize the package with project.toml (#130)
@@ -47,7 +51,7 @@ A major release with improved interface and new features.
 4. Configuration and secret management (AWS Systems Manager Parameter Store)
 5. Simple switch between production and devlopment stages
 6. Docker image management (AWS Elastic Container Registry)
-7. Artifacts management (AWS Simple Cloud Storage)
+7. Artifacts management (AWS Elastic Container Registry)
 8. Log management (AWS CloudWatch)
 9. Shared resource management (Virtual Private Cloud, Security Group)
 10. No need to pay and maintain a dedicated virtual instances!

--- a/handoff/config.py
+++ b/handoff/config.py
@@ -1,4 +1,4 @@
-VERSION = "0.4.2"
+VERSION = "0.4.3"
 VERSION_MINOR = ".".join(VERSION.split(".")[0:2])
 
 import datetime, os, re

--- a/handoff/services/cloud/aws/cloudformation_templates/task.yml
+++ b/handoff/services/cloud/aws/cloudformation_templates/task.yml
@@ -84,7 +84,7 @@ Resources:
     Properties:
       LogGroupName:
         Ref: LogGroup
-      FilterPattern: "?ERROR ?Error ?error ?CRITICAL ?Exception"
+      FilterPattern: '?"ended with exit code 1" ?"exited with code 1" ?"CRITICAL" ?"Traceback (most recent call last)"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: !Sub ${ApplicationPrefix}-${ResourceGroup}

--- a/handoff/services/cloud/aws/kaniko_config/task.yml
+++ b/handoff/services/cloud/aws/kaniko_config/task.yml
@@ -84,7 +84,7 @@ Resources:
     Properties:
       LogGroupName:
         Ref: LogGroup
-      FilterPattern: "?ERROR ?Error ?error ?CRITICAL ?Exception"
+      FilterPattern: '?"ended with exit code 1" ?"exited with code 1" ?"CRITICAL" ?"Traceback (most recent call last)"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: !Sub ${ApplicationPrefix}-${ResourceGroup}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "handoff"
-version = "0.4.2"
+version = "0.4.3"
 description = "Deploy configurable unix pipeline jobs serverlessly."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/unit/test_aws_task_templates.py
+++ b/tests/unit/test_aws_task_templates.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import yaml
+
 
 EXPECTED_ERROR_FILTER_PATTERN = (
     '?"ended with exit code 1" ?"exited with code 1" ?"CRITICAL" '
@@ -12,12 +14,35 @@ TASK_TEMPLATE_PATHS = [
 ]
 
 
+class CloudFormationLoader(yaml.SafeLoader):
+    pass
+
+
+def construct_cloudformation_value(loader, _tag_suffix, node):
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_scalar(node)
+
+
+CloudFormationLoader.add_multi_constructor("!", construct_cloudformation_value)
+
+
+def load_template(path):
+    return yaml.load(path.read_text(), Loader=CloudFormationLoader)
+
+
 def test_error_metric_filter_pattern_is_tightened():
     for path in TASK_TEMPLATE_PATHS:
-        template = path.read_text()
+        template_text = path.read_text()
+        template = load_template(path)
+        filter_pattern = template["Resources"]["ErrorLogMetricFilter"]["Properties"][
+            "FilterPattern"
+        ]
 
-        assert f"FilterPattern: '{EXPECTED_ERROR_FILTER_PATTERN}'" in template
-        assert "?ERROR ?Error ?error ?CRITICAL ?Exception" not in template
+        assert filter_pattern == EXPECTED_ERROR_FILTER_PATTERN
+        assert "?ERROR ?Error ?error ?CRITICAL ?Exception" not in template_text
 
 
 def test_task_templates_do_not_contain_account_specific_arns():

--- a/tests/unit/test_aws_task_templates.py
+++ b/tests/unit/test_aws_task_templates.py
@@ -1,14 +1,27 @@
 from pathlib import Path
 
 
-TASK_TEMPLATES = [
+EXPECTED_ERROR_FILTER_PATTERN = (
+    '?"ended with exit code 1" ?"exited with code 1" ?"CRITICAL" '
+    '?"Traceback (most recent call last)"'
+)
+
+TASK_TEMPLATE_PATHS = [
     Path("handoff/services/cloud/aws/cloudformation_templates/task.yml"),
     Path("handoff/services/cloud/aws/kaniko_config/task.yml"),
 ]
 
 
-def test_task_templates_do_not_embed_account_specific_arns():
-    for template_path in TASK_TEMPLATES:
-        template = template_path.read_text()
+def test_error_metric_filter_pattern_is_tightened():
+    for path in TASK_TEMPLATE_PATHS:
+        template = path.read_text()
+
+        assert f"FilterPattern: '{EXPECTED_ERROR_FILTER_PATTERN}'" in template
+        assert "?ERROR ?Error ?error ?CRITICAL ?Exception" not in template
+
+
+def test_task_templates_do_not_contain_account_specific_arns():
+    for path in TASK_TEMPLATE_PATHS:
+        template = path.read_text()
 
         assert "arn:aws:iam::" not in template


### PR DESCRIPTION
## Summary

This tightens the default CloudWatch `ErrorLogMetricFilter` pattern used by handoff task CloudFormation templates. The previous broad substring pattern matched benign log lines that mentioned generic error words; the new pattern focuses on task-failure signals and Python traceback output.

Changed:

- Updated both AWS task templates to use the tightened error metric filter pattern.
- Added regression coverage for the expected parsed `FilterPattern` value and for avoiding account-specific IAM ARN literals in task templates.
- Bumped the package version metadata to `0.4.3` and added a `HISTORY.md` entry.

## Intentional scope

The tightened `-error` filter is intentionally narrower: it no longer treats generic error-like substrings, including Step Functions failure fields, as task error signals. Infra-level failures that do not emit a matching application log line should be covered separately by a started-vs-ended/completion-gap alarm; tracked in #137.

The filter also matches the common handoff task-failure strings for exit code `1`, plus `CRITICAL` and Python traceback output. Other non-zero exit codes without matching log output are part of the follow-up coverage gap above.

## Validation

- Ran the focused template regression checks directly:
  - `test_error_metric_filter_pattern_is_tightened`
  - `test_task_templates_do_not_contain_account_specific_arns`
- Pattern behavior was validated out of band with `aws logs test-metric-filter` examples in #133.

Full pytest execution was not available in this environment.

## Rollout note

After merge and release, existing deployments need a resource update or redeploy to adopt the new CloudFormation template. Redeploying with an older release will continue to provision the old broad pattern.