### PR TITLE
Fix NameError in schedule_delete and report real failures

### DIFF
--- a/handoff/services/cloud/__init__.py
+++ b/handoff/services/cloud/__init__.py
@@ -624,8 +624,8 @@ def schedule_delete(
     try:
         response = platform.unschedule_job(target_id)
     except Exception as e:
-        response = str(e)
-    return {"status": "success", "result": responses}
+        return {"status": "error", "message": str(e)}
+    return {"status": "success", "result": response}
 
 
 def schedule_list(


### PR DESCRIPTION
## Summary
- `schedule_delete()` referenced the undefined variable `responses` (plural), so every successful delete raised a `NameError` that was reported back as `status: error`.
- The `except` branch also stored the error text in `response` but the function unconditionally returned `status: success`, so a genuine failure in `unschedule_job()` would have been silently masked as success once the `NameError` was fixed.

## Fix
- Return `{"status": "error", "message": str(e)}` immediately when `unschedule_job()` raises.
- Return `{"status": "success", "result": response}` using the correctly-named variable on the success path.

Fixes #131

## Test plan
- [x] Verified the corrected file parses (`ast.parse`)
- [ ] Manual repro: `handoff cloud schedule delete -p <project_dir> -s <stage> -v target_id=<id>` should now return `status: success` on a real delete, and `status: error` with the underlying message if `unschedule_job` raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)