### PR TITLE
Do not raise when a task has zero EventBridge schedules

### DIFF
--- a/handoff/services/cloud/aws/events.py
+++ b/handoff/services/cloud/aws/events.py
@@ -177,11 +177,9 @@ def list_schedules(
         "NamePrefix": rule_prefix,
     }
     rules = client.list_rules(**kwargs)
-    if not rules.get("Rules"):
-        raise Exception("No rules found")
 
     response = list()
-    for rule in rules.get("Rules"):
+    for rule in rules.get("Rules", []):
         targets = client.list_targets_by_rule(Rule=rule["Name"])
         record = {"rule": rule, "targets": targets.get("Targets")}
         response.append(record)

--- a/tests/unit/test_events_list_schedules.py
+++ b/tests/unit/test_events_list_schedules.py
@@ -1,0 +1,46 @@
+from handoff.services.cloud.aws import events
+
+
+class FakeEventsClient:
+    def __init__(self, rules):
+        self._rules = rules
+        self.list_targets_by_rule_calls = []
+
+    def list_rules(self, **kwargs):
+        return self._rules
+
+    def list_targets_by_rule(self, **kwargs):
+        self.list_targets_by_rule_calls.append(kwargs)
+        return {"Targets": []}
+
+
+def test_list_schedules_returns_empty_list_when_no_rules(monkeypatch):
+    client = FakeEventsClient({"Rules": []})
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules("task-stack")
+
+    assert result == []
+    assert client.list_targets_by_rule_calls == []
+
+
+def test_list_schedules_returns_empty_list_when_rules_key_missing(monkeypatch):
+    client = FakeEventsClient({})
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules("task-stack")
+
+    assert result == []
+    assert client.list_targets_by_rule_calls == []
+
+
+def test_list_schedules_returns_records_when_rules_present(monkeypatch):
+    rules = {"Rules": [{"Name": "handoff-etl-task-stack-1"}]}
+    client = FakeEventsClient(rules)
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules("task-stack")
+
+    assert len(result) == 1
+    assert result[0]["rule"]["Name"] == "handoff-etl-task-stack-1"
+    assert len(client.list_targets_by_rule_calls) == 1


### PR DESCRIPTION
## Summary
- `list_schedules()` in `handoff/services/cloud/aws/events.py` raised an exception when `events:ListRules` matched zero rules for a task's prefix, even though an empty schedule set is a normal, expected state (e.g. right after deleting a task's last schedule).
- The caller in `handoff/services/cloud/aws/__init__.py` catches that exception and logs it via `LOGGER.error(e)`, which produced the spurious `ERROR - No rules found` log line reported in the issue, even though `handoff cloud schedule list` still correctly returned `schedules: []`.

## Fix
- Removed the `raise Exception("No rules found")` guard and default to an empty list when `Rules` is missing/empty, so a zero-schedule task no longer triggers an ERROR-level log.

Fixes #132

## Test plan
- [x] Verified the corrected file parses (`ast.parse`)
- [ ] Manual repro: `handoff cloud schedule list -p <project_dir> -s <stage>` on a task with zero schedules should return `schedules: []` with no ERROR log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
