### PR TITLE
Add schedule list scope option to fix task-name-prefix over-matching

### DIFF
--- a/handoff/services/cloud/__init__.py
+++ b/handoff/services/cloud/__init__.py
@@ -635,18 +635,46 @@ def schedule_list(
     **kwargs) -> None:
     """`handoff cloud schedule list`
     List the scheduled tasks
+
+    Use --vars (-v) option to:
+    - scope: Controls how deployed EventBridge rules are matched to this
+      task. Rule names only differ from a sibling task's rules (e.g.
+      "foo" vs "foo-rest") by a plain string prefix, so this choice
+      matters:
+      - declared (default): only rules whose target_id is already
+        declared in this project's local schedules config. Safest;
+        will not surface schedules that exist in AWS but were never
+        declared locally.
+      - prefix: legacy behavior, matches any rule whose name starts
+        with this task's stack name. Can over-match a sibling task
+        whose name extends this one.
+      - all: every handoff-managed schedule in the AWS account,
+        regardless of task.
+    - include_unpublished: also include locally declared schedules that
+      have not been deployed yet.
     """
     state = _get_state()
     platform = get_platform()
     state.validate_env()
-    schedules = platform.list_schedules(**vars)
+
+    scope = vars.get("scope", "declared")
+    config = None
+    if scope == "declared" or vars.get("include_unpublished"):
+        config = admin._config_get_local(project_dir, workspace_dir)
+
+    list_vars = dict(vars)
+    if scope == "declared":
+        list_vars["target_ids"] = [
+            str(s["target_id"]) for s in config.get("schedules", [])
+        ]
+
+    schedules = platform.list_schedules(**list_vars)
     target_ids = []
     for s in schedules["schedules"]:
         target_ids.append(str(s["target_id"]))
         s["status"] = "scheduled"
 
     if vars.get("include_unpublished"):
-        config = admin._config_get_local(project_dir, workspace_dir)
         local_schedules = config.get("schedules", [])
         for s in local_schedules:
             s["target_id"] = str(s["target_id"])

--- a/handoff/services/cloud/aws/__init__.py
+++ b/handoff/services/cloud/aws/__init__.py
@@ -926,11 +926,16 @@ def unschedule_job(target_id):
     return response
 
 
-def list_schedules(full=False, **kwargs):
+def list_schedules(full=False, scope="declared", target_ids=None, **kwargs):
     state = get_state()
     task_stack = _get_task_stack_name()
     try:
-        response = events.list_schedules(task_stack, cred_keys=_get_cred_keys())
+        response = events.list_schedules(
+            task_stack,
+            cred_keys=_get_cred_keys(),
+            scope=scope,
+            target_ids=target_ids,
+        )
     except Exception as e:
         LOGGER.error(e)
         response = []

--- a/handoff/services/cloud/aws/__init__.py
+++ b/handoff/services/cloud/aws/__init__.py
@@ -927,6 +927,11 @@ def unschedule_job(target_id):
 
 
 def list_schedules(full=False, scope="declared", target_ids=None, **kwargs):
+    if scope not in events.SCHEDULE_LIST_SCOPES:
+        raise ValueError(
+            f"Invalid scope {scope!r}. "
+            f"Must be one of {events.SCHEDULE_LIST_SCOPES}.")
+
     state = get_state()
     task_stack = _get_task_stack_name()
     try:

--- a/handoff/services/cloud/aws/events.py
+++ b/handoff/services/cloud/aws/events.py
@@ -6,6 +6,7 @@ from . import credentials as cred
 from . import cloudformation as cfn, iam, sts, stepfunctions as stepfns
 
 from handoff import utils
+from handoff.config import APP_PREFIX
 
 
 LOGGER = utils.get_logger()
@@ -167,19 +168,63 @@ def unschedule_job(
     client.delete_rule(Name=rule_name)
 
 
+def _list_rules_by_prefix(client, name_prefix):
+    rules = []
+    kwargs = {"NamePrefix": name_prefix}
+    while True:
+        page = client.list_rules(**kwargs)
+        rules.extend(page.get("Rules", []))
+        next_token = page.get("NextToken")
+        if not next_token:
+            break
+        kwargs["NextToken"] = next_token
+    return rules
+
+
 def list_schedules(
         task_stack,
         cred_keys: dict = {},
+        scope: str = "declared",
+        target_ids: list = None,
         ):
+    """List the EventBridge rules (schedules) for a task.
+
+    `scope` controls how rules are matched to this task, since rule names
+    (`f"{task_stack}-{target_id}"`) are only distinguished from a sibling
+    task's rules (e.g. `<task>` vs `<task>-rest`) by a plain string prefix,
+    which EventBridge's `NamePrefix` matches loosely:
+
+    - "declared" (default): only rules whose target_id is in `target_ids`
+      (the project's locally declared schedules). Safest; will not surface
+      schedules that exist in AWS but were never declared locally.
+    - "prefix": legacy behavior - anything matching `NamePrefix=task_stack`.
+      Can over-match sibling tasks whose name extends this one.
+    - "all": every handoff-managed rule in the account, regardless of task.
+    """
     client = get_client(cred_keys)
-    rule_prefix = task_stack
-    kwargs = {
-        "NamePrefix": rule_prefix,
-    }
-    rules = client.list_rules(**kwargs)
+
+    if scope == "all":
+        candidates = _list_rules_by_prefix(client, f"{APP_PREFIX}-")
+    else:
+        candidates = _list_rules_by_prefix(client, task_stack)
+
+    if scope == "declared":
+        if not target_ids:
+            candidates = []
+        else:
+            wanted_names = {f"{task_stack}-{tid}" for tid in target_ids}
+            candidates = [r for r in candidates if r["Name"] in wanted_names]
+    elif scope == "prefix":
+        LOGGER.warning(
+            "cloud schedule list scope=prefix can over-match rules "
+            "belonging to a sibling task whose name extends this task's "
+            "name (e.g. '%s' would also match '%s-rest-...'). Prefer "
+            "scope=declared or verify results with scope=all.",
+            task_stack, task_stack,
+        )
 
     response = list()
-    for rule in rules.get("Rules", []):
+    for rule in candidates:
         targets = client.list_targets_by_rule(Rule=rule["Name"])
         record = {"rule": rule, "targets": targets.get("Targets")}
         response.append(record)

--- a/handoff/services/cloud/aws/events.py
+++ b/handoff/services/cloud/aws/events.py
@@ -168,6 +168,9 @@ def unschedule_job(
     client.delete_rule(Name=rule_name)
 
 
+SCHEDULE_LIST_SCOPES = ("declared", "prefix", "all")
+
+
 def _list_rules_by_prefix(client, name_prefix):
     rules = []
     kwargs = {"NamePrefix": name_prefix}
@@ -201,6 +204,10 @@ def list_schedules(
       Can over-match sibling tasks whose name extends this one.
     - "all": every handoff-managed rule in the account, regardless of task.
     """
+    if scope not in SCHEDULE_LIST_SCOPES:
+        raise ValueError(
+            f"Invalid scope {scope!r}. Must be one of {SCHEDULE_LIST_SCOPES}.")
+
     client = get_client(cred_keys)
 
     if scope == "all":

--- a/tests/unit/test_events_list_schedules.py
+++ b/tests/unit/test_events_list_schedules.py
@@ -2,45 +2,138 @@ from handoff.services.cloud.aws import events
 
 
 class FakeEventsClient:
-    def __init__(self, rules):
-        self._rules = rules
+    """Simulates the subset of boto3's EventBridge client used by
+    list_schedules: NamePrefix filtering (with pagination) and
+    per-rule target lookups.
+    """
+
+    def __init__(self, rule_names, page_size=None):
+        self._rules = [{"Name": n, "ScheduleExpression": "cron(0 0 * * ? *)"}
+                       for n in rule_names]
+        self._page_size = page_size
+        self.list_rules_calls = []
         self.list_targets_by_rule_calls = []
 
     def list_rules(self, **kwargs):
-        return self._rules
+        self.list_rules_calls.append(kwargs)
+        prefix = kwargs.get("NamePrefix", "")
+        matches = [r for r in self._rules if r["Name"].startswith(prefix)]
+
+        if not self._page_size:
+            return {"Rules": matches}
+
+        token = kwargs.get("NextToken")
+        start = int(token) if token else 0
+        end = start + self._page_size
+        page = {"Rules": matches[start:end]}
+        if end < len(matches):
+            page["NextToken"] = str(end)
+        return page
 
     def list_targets_by_rule(self, **kwargs):
         self.list_targets_by_rule_calls.append(kwargs)
         return {"Targets": []}
 
 
+def test_declared_scope_filters_out_sibling_task_rule(monkeypatch):
+    # Reproduces the #134 repro: "saasoptics-tiny" and
+    # "saasoptics-tiny-rest" are sibling tasks whose stack names share a
+    # prefix, so a NamePrefix match on the shorter one also matches rules
+    # belonging to the longer one.
+    client = FakeEventsClient([
+        "handoff-etl-saasoptics-tiny-tiny-1",
+        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+    ])
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules(
+        "handoff-etl-saasoptics-tiny",
+        scope="declared",
+        target_ids=["tiny-1"],
+    )
+
+    assert [r["rule"]["Name"] for r in result] == [
+        "handoff-etl-saasoptics-tiny-tiny-1"
+    ]
+
+
+def test_declared_scope_returns_empty_when_no_target_ids(monkeypatch):
+    client = FakeEventsClient(["handoff-etl-task-stack-1"])
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules("handoff-etl-task-stack", scope="declared")
+
+    assert result == []
+    assert client.list_targets_by_rule_calls == []
+
+
+def test_prefix_scope_still_over_matches_sibling_task(monkeypatch):
+    # Documents the known limitation of the legacy "prefix" scope: it is
+    # kept only for backward compatibility and explicitly does not fix
+    # the #134 over-match.
+    client = FakeEventsClient([
+        "handoff-etl-saasoptics-tiny-tiny-1",
+        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+    ])
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules(
+        "handoff-etl-saasoptics-tiny", scope="prefix")
+
+    names = {r["rule"]["Name"] for r in result}
+    assert names == {
+        "handoff-etl-saasoptics-tiny-tiny-1",
+        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+    }
+
+
+def test_all_scope_ignores_task_stack_and_returns_every_handoff_rule(monkeypatch):
+    client = FakeEventsClient([
+        "handoff-etl-saasoptics-tiny-tiny-1",
+        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+        "handoff-role-other-thing",
+    ])
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules("handoff-etl-saasoptics-tiny", scope="all")
+
+    names = {r["rule"]["Name"] for r in result}
+    assert names == {
+        "handoff-etl-saasoptics-tiny-tiny-1",
+        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+        "handoff-role-other-thing",
+    }
+    assert client.list_rules_calls[0]["NamePrefix"] == "handoff-"
+
+
+def test_list_rules_by_prefix_paginates(monkeypatch):
+    client = FakeEventsClient(
+        ["handoff-etl-task-stack-1", "handoff-etl-task-stack-2",
+         "handoff-etl-task-stack-3"],
+        page_size=1,
+    )
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    result = events.list_schedules(
+        "handoff-etl-task-stack",
+        scope="declared",
+        target_ids=["1", "2", "3"],
+    )
+
+    assert len(client.list_rules_calls) == 3
+    assert {r["rule"]["Name"] for r in result} == {
+        "handoff-etl-task-stack-1",
+        "handoff-etl-task-stack-2",
+        "handoff-etl-task-stack-3",
+    }
+
+
 def test_list_schedules_returns_empty_list_when_no_rules(monkeypatch):
-    client = FakeEventsClient({"Rules": []})
+    client = FakeEventsClient([])
     monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
 
-    result = events.list_schedules("task-stack")
+    result = events.list_schedules(
+        "handoff-etl-task-stack", scope="prefix")
 
     assert result == []
     assert client.list_targets_by_rule_calls == []
-
-
-def test_list_schedules_returns_empty_list_when_rules_key_missing(monkeypatch):
-    client = FakeEventsClient({})
-    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
-
-    result = events.list_schedules("task-stack")
-
-    assert result == []
-    assert client.list_targets_by_rule_calls == []
-
-
-def test_list_schedules_returns_records_when_rules_present(monkeypatch):
-    rules = {"Rules": [{"Name": "handoff-etl-task-stack-1"}]}
-    client = FakeEventsClient(rules)
-    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
-
-    result = events.list_schedules("task-stack")
-
-    assert len(result) == 1
-    assert result[0]["rule"]["Name"] == "handoff-etl-task-stack-1"
-    assert len(client.list_targets_by_rule_calls) == 1

--- a/tests/unit/test_events_list_schedules.py
+++ b/tests/unit/test_events_list_schedules.py
@@ -1,3 +1,5 @@
+import pytest
+
 from handoff.services.cloud.aws import events
 
 
@@ -36,32 +38,31 @@ class FakeEventsClient:
 
 
 def test_declared_scope_filters_out_sibling_task_rule(monkeypatch):
-    # Reproduces the #134 repro: "saasoptics-tiny" and
-    # "saasoptics-tiny-rest" are sibling tasks whose stack names share a
-    # prefix, so a NamePrefix match on the shorter one also matches rules
-    # belonging to the longer one.
+    # "handoff-etl-widgets" and "handoff-etl-widgets-legacy" are sibling
+    # tasks whose stack names share a prefix, so a NamePrefix match on the
+    # shorter one also matches rules belonging to the longer one.
     client = FakeEventsClient([
-        "handoff-etl-saasoptics-tiny-tiny-1",
-        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+        "handoff-etl-widgets-daily-1",
+        "handoff-etl-widgets-legacy-nightly-1",
     ])
     monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
 
     result = events.list_schedules(
-        "handoff-etl-saasoptics-tiny",
+        "handoff-etl-widgets",
         scope="declared",
-        target_ids=["tiny-1"],
+        target_ids=["daily-1"],
     )
 
     assert [r["rule"]["Name"] for r in result] == [
-        "handoff-etl-saasoptics-tiny-tiny-1"
+        "handoff-etl-widgets-daily-1"
     ]
 
 
 def test_declared_scope_returns_empty_when_no_target_ids(monkeypatch):
-    client = FakeEventsClient(["handoff-etl-task-stack-1"])
+    client = FakeEventsClient(["handoff-etl-widgets-daily-1"])
     monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
 
-    result = events.list_schedules("handoff-etl-task-stack", scope="declared")
+    result = events.list_schedules("handoff-etl-widgets", scope="declared")
 
     assert result == []
     assert client.list_targets_by_rule_calls == []
@@ -72,35 +73,34 @@ def test_prefix_scope_still_over_matches_sibling_task(monkeypatch):
     # kept only for backward compatibility and explicitly does not fix
     # the #134 over-match.
     client = FakeEventsClient([
-        "handoff-etl-saasoptics-tiny-tiny-1",
-        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+        "handoff-etl-widgets-daily-1",
+        "handoff-etl-widgets-legacy-nightly-1",
     ])
     monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
 
-    result = events.list_schedules(
-        "handoff-etl-saasoptics-tiny", scope="prefix")
+    result = events.list_schedules("handoff-etl-widgets", scope="prefix")
 
     names = {r["rule"]["Name"] for r in result}
     assert names == {
-        "handoff-etl-saasoptics-tiny-tiny-1",
-        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+        "handoff-etl-widgets-daily-1",
+        "handoff-etl-widgets-legacy-nightly-1",
     }
 
 
 def test_all_scope_ignores_task_stack_and_returns_every_handoff_rule(monkeypatch):
     client = FakeEventsClient([
-        "handoff-etl-saasoptics-tiny-tiny-1",
-        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+        "handoff-etl-widgets-daily-1",
+        "handoff-etl-widgets-legacy-nightly-1",
         "handoff-role-other-thing",
     ])
     monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
 
-    result = events.list_schedules("handoff-etl-saasoptics-tiny", scope="all")
+    result = events.list_schedules("handoff-etl-widgets", scope="all")
 
     names = {r["rule"]["Name"] for r in result}
     assert names == {
-        "handoff-etl-saasoptics-tiny-tiny-1",
-        "handoff-etl-saasoptics-tiny-rest-so-tiny-1",
+        "handoff-etl-widgets-daily-1",
+        "handoff-etl-widgets-legacy-nightly-1",
         "handoff-role-other-thing",
     }
     assert client.list_rules_calls[0]["NamePrefix"] == "handoff-"
@@ -108,23 +108,23 @@ def test_all_scope_ignores_task_stack_and_returns_every_handoff_rule(monkeypatch
 
 def test_list_rules_by_prefix_paginates(monkeypatch):
     client = FakeEventsClient(
-        ["handoff-etl-task-stack-1", "handoff-etl-task-stack-2",
-         "handoff-etl-task-stack-3"],
+        ["handoff-etl-widgets-1", "handoff-etl-widgets-2",
+         "handoff-etl-widgets-3"],
         page_size=1,
     )
     monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
 
     result = events.list_schedules(
-        "handoff-etl-task-stack",
+        "handoff-etl-widgets",
         scope="declared",
         target_ids=["1", "2", "3"],
     )
 
     assert len(client.list_rules_calls) == 3
     assert {r["rule"]["Name"] for r in result} == {
-        "handoff-etl-task-stack-1",
-        "handoff-etl-task-stack-2",
-        "handoff-etl-task-stack-3",
+        "handoff-etl-widgets-1",
+        "handoff-etl-widgets-2",
+        "handoff-etl-widgets-3",
     }
 
 
@@ -132,8 +132,17 @@ def test_list_schedules_returns_empty_list_when_no_rules(monkeypatch):
     client = FakeEventsClient([])
     monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
 
-    result = events.list_schedules(
-        "handoff-etl-task-stack", scope="prefix")
+    result = events.list_schedules("handoff-etl-widgets", scope="prefix")
 
     assert result == []
     assert client.list_targets_by_rule_calls == []
+
+
+def test_invalid_scope_raises_instead_of_falling_back_to_prefix(monkeypatch):
+    client = FakeEventsClient(["handoff-etl-widgets-daily-1"])
+    monkeypatch.setattr(events, "get_client", lambda cred_keys={}: client)
+
+    with pytest.raises(ValueError):
+        events.list_schedules("handoff-etl-widgets", scope="declare")
+
+    assert client.list_rules_calls == []


### PR DESCRIPTION
## Summary
`list_schedules()` matched EventBridge rules to a task using a plain `NamePrefix` match on the task's stack name (`f"{APP_PREFIX}-{resource_group}-{task_name}"`). Since rule names are `f"{task_stack}-{target_id}"`, a sibling task whose name extends this one (e.g. `<task>` vs `<task>-rest`) is itself a string-prefix of the sibling's rule names, so `NamePrefix` matching pulls in the sibling's rules too — misleading output, and risky next to `schedule delete`.

Rule names can't be reliably disambiguated by string matching alone, because the `target_id` segment is arbitrary and can itself contain hyphens. Rather than pick one heuristic, this adds an explicit `scope` option so the caller controls the tradeoff.

## Fix
`handoff cloud schedule list -v scope=<mode>`:
- **`declared`** (new default) — only returns rules whose `target_id` is already declared in the project's local `schedules:` config. Exact match against `f"{task_stack}-{target_id}"`, so no over-matching is possible. Tradeoff: a schedule created ad hoc (e.g. via `-v target_id=X` without adding it to the project config) won't be discovered by `list` under this mode.
- **`prefix`** — the old `NamePrefix`-based behavior, kept for backward compatibility. Now logs a `LOGGER.warning` when used, since it can still over-match a sibling task.
- **`all`** — every handoff-managed rule in the AWS account (`NamePrefix=f"{APP_PREFIX}-"`), regardless of task. Useful to audit what's actually deployed. No new IAM permission needed — `events:ListRules`/`events:ListTargetsByRule` in `role.yml` are already scoped account-wide (`arn:aws:events:*:${AWS::AccountId}:*`), not restricted by name prefix.

Also added pagination (`NextToken`) to the underlying `list_rules` call, since `scope=all` can return more than one page in an account with many scheduled tasks.

Fixes #134

## Test plan
- [x] `tests/unit/test_events_list_schedules.py` — added cases for all three scopes, including a repro of the sibling-task over-match with `scope=prefix` (documented as a known limitation of that mode) and confirmation that `scope=declared` excludes it. Also covers `NextToken` pagination. Full suite: `.venv/bin/python -m pytest tests/unit` → 16 passed.
- [x] Manually validated read-only (`schedule list`, no mutations) against a real production AWS account containing a genuine sibling-task-name collision (task A's stack name is a literal string prefix of task B's stack name, both currently deployed). Confirmed `scope=prefix` reproduces the exact over-match described in this issue (returns rules belonging to unrelated sibling tasks), while `scope=declared` returns only the querying task's own rules, and `scope=all` returns the full account-wide rule set without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
