### PR TITLE
Add timeout metric filter to default task CloudFormation templates

### DIFF
--- a/handoff/services/cloud/aws/cloudformation_templates/task.yml
+++ b/handoff/services/cloud/aws/cloudformation_templates/task.yml
@@ -112,6 +112,17 @@ Resources:
           MetricNamespace: !Sub ${ApplicationPrefix}-${ResourceGroup}
           MetricName: !Sub ${AWS::StackName}-ended
 
+  TimeoutLogMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName:
+        Ref: LogGroup
+      FilterPattern: "?WARNING Timeout"
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: !Sub ${ApplicationPrefix}-${ResourceGroup}
+          MetricName: !Sub ${AWS::StackName}-timeout
+
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:

--- a/handoff/services/cloud/aws/kaniko_config/task.yml
+++ b/handoff/services/cloud/aws/kaniko_config/task.yml
@@ -112,6 +112,17 @@ Resources:
           MetricNamespace: !Sub ${ApplicationPrefix}-${ResourceGroup}
           MetricName: !Sub ${AWS::StackName}-ended
 
+  TimeoutLogMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName:
+        Ref: LogGroup
+      FilterPattern: "?WARNING Timeout"
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: !Sub ${ApplicationPrefix}-${ResourceGroup}
+          MetricName: !Sub ${AWS::StackName}-timeout
+
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:

--- a/tests/unit/test_aws_task_templates.py
+++ b/tests/unit/test_aws_task_templates.py
@@ -50,3 +50,29 @@ def test_task_templates_do_not_contain_account_specific_arns():
         template = path.read_text()
 
         assert "arn:aws:iam::" not in template
+
+
+def test_timeout_log_metric_filter_is_present():
+    for path in TASK_TEMPLATE_PATHS:
+        template = load_template(path)
+        resources = template["Resources"]
+        metric_filter = resources["TimeoutLogMetricFilter"]
+
+        assert metric_filter["Type"] == "AWS::Logs::MetricFilter"
+        assert metric_filter["Properties"]["FilterPattern"] == "?WARNING Timeout"
+
+        transformation = metric_filter["Properties"]["MetricTransformations"][0]
+        assert transformation["MetricName"] == "${AWS::StackName}-timeout"
+
+        # Existing started/ended/error filters must be untouched by this change.
+        assert resources["ErrorLogMetricFilter"]["Properties"]["FilterPattern"] == (
+            EXPECTED_ERROR_FILTER_PATTERN
+        )
+        assert (
+            resources["StartedLogMetricFilter"]["Properties"]["FilterPattern"]
+            == "?Job started at"
+        )
+        assert (
+            resources["EndedLogMetricFilter"]["Properties"]["FilterPattern"]
+            == "?Job ended at"
+        )


### PR DESCRIPTION
## Summary
Adds a `TimeoutLogMetricFilter` to the default task CloudFormation template (`handoff/services/cloud/aws/cloudformation_templates/task.yml`) and its kaniko variant (`handoff/services/cloud/aws/kaniko_config/task.yml`), matching the existing `StartedLogMetricFilter`/`EndedLogMetricFilter`/`ErrorLogMetricFilter` resources.

When a run hits `global_timeout`, `tap-rest-api` logs `LOGGER.warning(f"Timeout {global_timeout} reached. Not doing further sync.")`. There was previously no built-in CloudWatch metric for that, so observing timeouts required a hand-maintained fork of the default template.

## Change
Purely additive — one new `AWS::Logs::MetricFilter` resource added after `EndedLogMetricFilter` in both templates, exactly as specified in the issue:

```yaml
  TimeoutLogMetricFilter:
    Type: AWS::Logs::MetricFilter
    Properties:
      LogGroupName:
        Ref: LogGroup
      FilterPattern: "?WARNING Timeout"
      MetricTransformations:
        - MetricValue: "1"
          MetricNamespace: !Sub ${ApplicationPrefix}-${ResourceGroup}
          MetricName: !Sub ${AWS::StackName}-timeout
```

`ErrorLogMetricFilter` (the #133 tightened pattern) is untouched, and a new test asserts that explicitly.

Fixes #138

## Test plan
- [x] `tests/unit/test_aws_task_templates.py` — added `test_timeout_log_metric_filter_is_present`, asserting the new filter's type/pattern/metric name in both templates, and that the started/ended/error filters are unchanged. Full suite: `.venv/bin/python -m pytest tests/unit` → 18 passed.
- [x] Validated both modified templates against the real AWS CloudFormation API (`aws cloudformation validate-template`, read-only, no resources created) — both parse and validate successfully.
- [x] Confirmed the filter pattern actually matches `tap-rest-api`'s real timeout log line using `aws logs test-metric-filter` (read-only, no resources created): matched a realistic `[...] [ WARNING] - Timeout <n> reached. Not doing further sync. - (sync.py:188)` line, and correctly did *not* match unrelated INFO-level lines (including one that happens to contain the lowercase substring "timeout").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
