### PR TITLE
Document alarming on task completion gaps (started-vs-ended blind spots)

### DIFF
--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -210,11 +210,22 @@ aws cloudformation create-stack \
       ParameterKey=AlarmEmail,ParameterValue=<your-email>
 ```
 
-If you also want to catch a task that starts but *stalls* mid-run with no
-`global_timeout` set (so `ExecutionsTimedOut` never fires), you can build a
-secondary alarm on the existing `<stack>-started` / `<stack>-ended` metric
-filters using CloudWatch metric math (`started_sum - ended_sum`, evaluated
-over a period comfortably longer than the task's expected runtime). Keep in
-mind this only complements the alarm above — since `<stack>-started` is only
-incremented once the task process is already running, it cannot see any of
-the three startup-time gaps this section opened with.
+Note there are two independent timeout mechanisms at play. The Step
+Functions state machine itself always has a `TimeoutSeconds` (the
+`state_machine_timeout` schedule parameter, 4 hours by default), so
+`ExecutionsTimedOut` will eventually fire for a genuinely hung task even if
+the application never sets its own timeout. The application-level
+`global_timeout` (see the timeout metric filter above) is a separate,
+usually much shorter, internal mechanism that lets the process exit
+gracefully and log a warning well before the state machine's hard limit
+would ever be hit.
+
+If you want to detect a stall *faster* than the state machine's default
+timeout — e.g. get paged within 30 minutes instead of waiting up to 4
+hours — you can build a secondary alarm on the existing `<stack>-started` /
+`<stack>-ended` metric filters using CloudWatch metric math
+(`started_sum - ended_sum`, evaluated over a period comfortably longer than
+the task's expected runtime). This only complements the alarm above: since
+`<stack>-started` is only incremented once the task process is already
+running, it still cannot see the startup-time gaps this section opened
+with.

--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -159,3 +159,62 @@ fields @timestamp, @log, @message
 | filter @message like /(CRITICAL|Error|error)/
 | count() as errors by bin(1h)
 ```
+
+## Alarming on task completion gaps
+
+The default task template's `ErrorLogMetricFilter` is intentionally narrow: it
+matches specific application-level failure phrases (`ended with exit code 1`,
+`CRITICAL`, a Python traceback, etc.) so that unrelated log noise doesn't trip
+false alarms. The tradeoff is that it can only catch failures the task's own
+process got far enough to *log*. It cannot see:
+
+- task-startup failures before any application log line is emitted (e.g. the
+  container image can't be pulled, or the task can't be scheduled)
+- OOM or signal-based exits that never reach a matching log line
+- a task that hangs and never exits at all
+
+For a scheduled task, ECS Fargate execution is wrapped in an AWS Step
+Functions state machine (one per scheduled `target_id`), and Step Functions
+already emits `AWS/States` `ExecutionsFailed` and `ExecutionsTimedOut`
+metrics, dimensioned by `StateMachineArn`, that reflect the outcome of the
+*whole* execution regardless of whether the task process itself ever started
+or logged anything. These cover all three gaps above, and since they only
+fire once an execution has truly finished failing or timed out, a task whose
+container pull is retried and eventually succeeds within the same execution
+will not trip the alarm — you won't get paged for something that already
+self-healed.
+
+To use them, find the state machine ARN for a scheduled task with:
+
+```
+handoff cloud schedule list -p <project_dir> -s <stage> -v full=True
+```
+
+Look for `targets[0].Arn` in the output — that's the `StateMachineArn`.
+
+The repo ships a ready-to-deploy, opt-in alarm stack at
+[`handoff/services/cloud/aws/cloudformation_templates/alarm.yml`](https://github.com/anelendata/handoff/blob/master/handoff/services/cloud/aws/cloudformation_templates/alarm.yml)
+(also included in the installed package under the same relative path). It
+creates an SNS topic with an email subscription plus the two alarms. Deploy
+it per task with the plain AWS CLI, since it's independent of handoff's own
+`cloud resources`/`cloud task` stacks:
+
+```
+aws cloudformation create-stack \
+  --stack-name <resource-group>-<task-name>-completion-alarm \
+  --template-body file://alarm.yml \
+  --parameters \
+      ParameterKey=ResourceGroup,ParameterValue=<resource-group> \
+      ParameterKey=TaskName,ParameterValue=<task-name> \
+      ParameterKey=StateMachineArn,ParameterValue=<state-machine-arn-from-above> \
+      ParameterKey=AlarmEmail,ParameterValue=<your-email>
+```
+
+If you also want to catch a task that starts but *stalls* mid-run with no
+`global_timeout` set (so `ExecutionsTimedOut` never fires), you can build a
+secondary alarm on the existing `<stack>-started` / `<stack>-ended` metric
+filters using CloudWatch metric math (`started_sum - ended_sum`, evaluated
+over a period comfortably longer than the task's expected runtime). Keep in
+mind this only complements the alarm above — since `<stack>-started` is only
+incremented once the task process is already running, it cannot see any of
+the three startup-time gaps this section opened with.

--- a/handoff/services/cloud/aws/cloudformation_templates/alarm.yml
+++ b/handoff/services/cloud/aws/cloudformation_templates/alarm.yml
@@ -19,7 +19,7 @@ Parameters:
 
   StateMachineArn:
     Type: String
-    Description: ARN of the task's Step Functions state machine (see `handoff cloud task status`)
+    Description: ARN of the task's Step Functions state machine (see `handoff cloud schedule list -v full=True`, field targets[0].Arn)
 
   AlarmEmail:
     Type: String

--- a/handoff/services/cloud/aws/cloudformation_templates/alarm.yml
+++ b/handoff/services/cloud/aws/cloudformation_templates/alarm.yml
@@ -1,4 +1,9 @@
 AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Optional, opt-in alarm stack for a handoff task's completion gaps
+  (task-startup failures, OOM/signal exits, hangs) that the default
+  ErrorLogMetricFilter cannot see, since those failures may occur before
+  the task emits any application log line. See docs/advanced_topics.md.
 Parameters:
   ResourceGroup:
     Type: String
@@ -14,15 +19,11 @@ Parameters:
 
   StateMachineArn:
     Type: String
-    Description: Email subscribing to the alarm
-    MaxLength: 27
-    AllowedPattern: "[a-zA-Z][a-zA-Z0-9_-]*"
+    Description: ARN of the task's Step Functions state machine (see `handoff cloud task status`)
 
   AlarmEmail:
     Type: String
-    Description: Email subscribing to the alarm
-    MaxLength: 27
-    AllowedPattern: "[a-zA-Z][a-zA-Z0-9_-]*"
+    Description: Email address to subscribe to the alarm SNS topic
 
 Resources:
   AlarmSNSTopic:
@@ -32,9 +33,9 @@ Resources:
       - Endpoint: !Sub ${AlarmEmail}
         Protocol: email
   ExecutionsFailedAlarm:
-    Condition: HasAlertingModule
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
+      AlarmName: !Sub ${ResourceGroup}-${TaskName}-executions-failed
       AlarmDescription: 'Failure while executing scheduled task.'
       Namespace: 'AWS/States'
       MetricName: ExecutionsFailed
@@ -51,9 +52,9 @@ Resources:
       AlarmActions:
       - !Ref AlarmSNSTopic
   ExecutionsTimeoutAlarm:
-    Condition: HasAlertingModule
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
+      AlarmName: !Sub ${ResourceGroup}-${TaskName}-executions-timed-out
       AlarmDescription: 'Executing scheduled task timed out.'
       Namespace: 'AWS/States'
       MetricName: ExecutionsTimedOut
@@ -69,4 +70,4 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
       - !Ref AlarmSNSTopic
-  
+

--- a/tests/unit/test_aws_alarm_template.py
+++ b/tests/unit/test_aws_alarm_template.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from test_aws_task_templates import CloudFormationLoader, load_template
+
+
+ALARM_TEMPLATE_PATH = Path(
+    "handoff/services/cloud/aws/cloudformation_templates/alarm.yml")
+
+
+def test_alarm_template_has_no_undefined_condition():
+    template = load_template(ALARM_TEMPLATE_PATH)
+    conditions = template.get("Conditions", {})
+
+    for resource in template["Resources"].values():
+        condition = resource.get("Condition")
+        assert condition is None or condition in conditions, (
+            f"Resource references undefined condition {condition!r}")
+
+
+def test_alarm_template_execution_alarms_target_step_functions_metrics():
+    template = load_template(ALARM_TEMPLATE_PATH)
+    resources = template["Resources"]
+
+    failed = resources["ExecutionsFailedAlarm"]["Properties"]
+    timed_out = resources["ExecutionsTimeoutAlarm"]["Properties"]
+
+    for alarm in (failed, timed_out):
+        assert alarm["Namespace"] == "AWS/States"
+        assert alarm["AlarmActions"] == ["AlarmSNSTopic"]
+
+    assert failed["MetricName"] == "ExecutionsFailed"
+    assert timed_out["MetricName"] == "ExecutionsTimedOut"
+
+
+def test_alarm_template_arn_and_email_params_accept_realistic_values():
+    template = load_template(ALARM_TEMPLATE_PATH)
+    params = template["Parameters"]
+
+    # These previously carried a copy-pasted MaxLength: 27 /
+    # AllowedPattern: "[a-zA-Z][a-zA-Z0-9_-]*" that rejected any real ARN
+    # or email address.
+    for key in ("StateMachineArn", "AlarmEmail"):
+        assert "AllowedPattern" not in params[key]
+        assert "MaxLength" not in params[key]


### PR DESCRIPTION
## Summary
Per the issue's acceptance criteria ("a default **or** documented way"), and after discussion on the issue about the right metric to use, this delivers a **documented** completion-gap alarm rather than a new required CFN resource — see the issue thread for the full design discussion.

The default task template's `ErrorLogMetricFilter` (tightened in #133) only catches failures a task's own process gets far enough to log. It cannot see:
- task-startup failures before any application log line is emitted (e.g. the container image can't be pulled)
- OOM or signal-based exits that never reach a matching log line
- a task that hangs and never exits

`<stack>-started`/`<stack>-ended` metric math can't fill this gap either, since `-started` is only incremented once the task process is already running — it's blind to the same startup-time failures.

## What this adds
1. **Docs** (`docs/advanced_topics.md`, new "Alarming on task completion gaps" section): explains the gap, and documents using the existing `AWS/States` `ExecutionsFailed`/`ExecutionsTimedOut` metrics on the task's Step Functions state machine instead — these reflect the outcome of the whole execution regardless of whether the task process ever started, and only fire once an execution has truly finished failing/timing out (so a transient issue that self-heals via retry within the same execution won't page anyone). Includes how to find the `StateMachineArn` (`handoff cloud schedule list -v full=True`) and a copy-paste `aws cloudformation create-stack` example. Also documents `started`/`ended` metric math as an optional secondary check for post-start hangs, with its blind spot called out explicitly.
2. **Fixed `cloudformation_templates/alarm.yml`**, adopted as the documented example (this file already modeled `ExecutionsFailedAlarm`/`ExecutionsTimeoutAlarm` but was broken and referenced by no command in the codebase):
   - Removed a `Condition: HasAlertingModule` reference with no matching `Conditions:` block anywhere in the template — this alone fails CloudFormation template validation.
   - `StateMachineArn` and `AlarmEmail` parameters carried a copy-pasted `MaxLength: 27` / `AllowedPattern: "[a-zA-Z][a-zA-Z0-9_-]*"` that rejects any real ARN (too long, contains `:`/`/`) or email address (contains `@`/`.`). Removed both constraints.
   - `StateMachineArn`'s `Description` was also copy-pasted ("Email subscribing to the alarm").
   - Added `AlarmName` to both alarms using the already-declared-but-previously-unused `ResourceGroup`/`TaskName` parameters, for predictable naming.

## Test plan
- [x] `tests/unit/test_aws_alarm_template.py` (new) — asserts no undefined `Condition` reference, both alarms target the correct `AWS/States` metric names and namespace, and the ARN/email parameters no longer carry the broken constraints. Full suite: `.venv/bin/python -m pytest tests/unit` → 20 passed.
- [x] Validated the fixed `alarm.yml` against the real AWS CloudFormation API (`aws cloudformation validate-template`, read-only, no resources created) — it now passes; before the fix it failed with `Template format error: Condition HasAlertingModule is not defined`.
- [x] Confirmed `AWS/States` `ExecutionsFailed`/`ExecutionsTimedOut` metrics actually exist (`aws cloudwatch list-metrics`, read-only) for a real deployed task's state machine.
- [x] Confirmed the "won't nag on transient issues" claim in the docs against real history: found a documented incident of a transient container-pull failure recurring across several tasks, then checked (read-only, `aws stepfunctions list-executions`) that every execution in that window still ended `SUCCEEDED` — i.e. `ExecutionsFailed` correctly did not increment for a self-healed retry, confirming the alarm's behavior matches what's documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
